### PR TITLE
Fix #19: use travis python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ python:
   - "3.6"
 sudo: false
 install:
-  #- sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  # Python 3.x is default
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -19,10 +13,14 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-
-  # Replace dep1 dep2 ... with your dependencies
-  - conda env create -f environment.yml
+  # Prepare env with Python version
+  - conda create -n birdy python=$TRAVIS_PYTHON_VERSION
+  # Update now the env with our environment
+  - conda env update -f environment.yml
   - source activate birdy
+  # Packages for testing
+  - conda install pytest flake8
+  # Install Emu WPS
   - python setup.py install
 script:
   - pytest -m 'not online'

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - pyyaml
   - mako
 # tests
-  - pytest
-  - flake8
+#  - pytest
+#  - flake8


### PR DESCRIPTION
This PR fixes #19.

Changes:
* build conda env with travis python version (2.7, 3.6)
* removed pytest and flake8 from dependencies ... can be installed manually.
