### PR TITLE
Fix #18: escape "%" in arpgarse help

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - '**/tests/**'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,3 @@
 ---
 exclude_paths:
-  - '**/tests/**'
+  - 'tests/**'

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,9 @@ __pycache__
 .tox
 nosetests.xml
 unit_tests/testdata.json
+.pytest_cache/
 
-# R 
+# R
 *.Rhistory
 
 # Eclipse / PyDev
@@ -81,5 +82,3 @@ testdata.json
 *.a
 *.mod
 *.out
-
-

--- a/birdy/wpsparser.py
+++ b/birdy/wpsparser.py
@@ -1,5 +1,5 @@
 import logging
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger("birdy")
 
 
 def is_complex_data(inoutput):
@@ -39,13 +39,13 @@ def parse_description(input):
     if hasattr(input, 'abstract'):
         description = description + ": " + str(input.abstract)
     default = parse_default(input)
-    # logger.debug("id=%s, datatype=%s", input.identifier, input.dataType)
+    # LOGGER.debug("id=%s, datatype=%s", input.identifier, input.dataType)
     if is_complex_data(input):
         if len(input.supportedValues) > 0:
             mime_types = ",".join([str(value.mimeType) for value in input.supportedValues])
             description = description + ", mime types=" + mime_types
     elif is_bbox_data(input):
-        logger.debug("bounding box input")
+        LOGGER.debug("bounding box input")
         if len(input.supportedValues) > 0:
             crs_list = ",".join(input.supportedValues)
             description = description + ", supported CRS=" + crs_list
@@ -96,14 +96,12 @@ def parse_nargs(input):
 
 
 def parse_process_help(process):
-    help = ''
-    if hasattr(process, "title"):
-        help = help + str(process.title) + ": "
-    if hasattr(process, "abstract"):
-        help = help + str(process.abstract)
+    help = "{}: {}".format(process.title or process.identifier, process.abstract or '')
+    # escape "%" with "%%" in argparse help
+    help = help.replace(r"%", r"%%")
     return help
 
 
 def parse_wps_description(wps):
-    description = "%s: %s" % (wps.identification.title, wps.identification.abstract)
+    description = "{0.title}: {0.abstract}".format(wps.identification)
     return description

--- a/tests/resources/wps_emu_caps.xml
+++ b/tests/resources/wps_emu_caps.xml
@@ -55,8 +55,8 @@
 		<wps:Process wps:processVersion="1.0">
 			<ows:Identifier>helloworld</ows:Identifier>
 			<ows:Title>Hello World</ows:Title>
-			<ows:Abstract>Welcome user and say hello ...</ows:Abstract>
-                        <ows:Metadata xlink:title="Documentation" xlink:href="http://emu.readthedocs.org/en/latest/" />
+			<ows:Abstract>Welcome user and say hello ... [100% quick response]</ows:Abstract>
+      <ows:Metadata xlink:title="Documentation" xlink:href="http://emu.readthedocs.org/en/latest/" />
 		</wps:Process>
 		<wps:Process wps:processVersion="2.0">
 			<ows:Identifier>ultimatequestionprocess</ows:Identifier>
@@ -81,19 +81,9 @@
                         <ows:Metadata xlink:title="Barfoo" xlink:href="http://bar/foo" />
 		</wps:Process>
 		<wps:Process wps:processVersion="1.0">
-			<ows:Identifier>multiplesources</ows:Identifier>
-			<ows:Title>Multiple Sources</ows:Title>
-			<ows:Abstract>Process with multiple different sources ...</ows:Abstract>
-		</wps:Process>
-		<wps:Process wps:processVersion="1.0">
 			<ows:Identifier>chomsky</ows:Identifier>
 			<ows:Title>Chomsky text generator</ows:Title>
 			<ows:Abstract> Generates a random chomsky text ...</ows:Abstract>
-		</wps:Process>
-		<wps:Process wps:processVersion="0.2">
-			<ows:Identifier>zonal_mean</ows:Identifier>
-			<ows:Title>Zonal Mean</ows:Title>
-			<ows:Abstract>zonal mean in NetCDF File.</ows:Abstract>
 		</wps:Process>
 	</wps:ProcessOfferings>
 	<wps:Languages>

--- a/tests/test_wpsparser.py
+++ b/tests/test_wpsparser.py
@@ -17,33 +17,25 @@ class WPSParserTestCase(WpsTestCase):
         # TODO: add test with unicode characters e.a:
         # http://geoprocessing.demo.52north.org:8080/52n-wps-webapp-3.3.1/WebProcessingService?Request=GetCapabilities&Service=WPS  # noqa
         result = parse_wps_description(self.wps)
-        assert 'Emu' in result
+        assert result == 'Emu: WPS processes for testing and demos.'
 
-    @pytest.mark.online
-    @pytest.mark.skip(reason="no way of currently testing this")
     def test_parse_process_help(self):
-        process = self.wps.describeprocess('hello')
+        process = self.wps.processes[0]
         result = parse_process_help(process)
-        assert 'Hello' in result
+        assert result == "Hello World: Welcome user and say hello ... [100%% quick response]"
 
-    @pytest.mark.online
-    @pytest.mark.skip(reason="no way of currently testing this")
     def test_is_complex_data(self):
-        process = self.wps.describeprocess('hello')
+        process = self.wps.processes[0]
         for input in process.dataInputs:
             assert is_complex_data(input) is False
 
-    @pytest.mark.online
-    @pytest.mark.skip(reason="no way of currently testing this")
     def test_parse_default(self):
-        process = self.wps.describeprocess('hello')
+        process = self.wps.processes[0]
         for input in process.dataInputs:
             assert parse_default(input) is False
 
-    @pytest.mark.online
-    @pytest.mark.skip(reason="no way of currently testing this")
     def test_parse_description(self):
-        process = self.wps.describeprocess('hello')
+        process = self.wps.processes[0]
         for input in process.dataInputs:
             result = parse_description(input)
             assert len(result) > 0


### PR DESCRIPTION
This PR fixes #18.

Changes:
* escape "%"  by "%%"  in argparse help
* update `.gitignore`
* update test suite
* using `format` in `wpsparser`