### PR TITLE
using WPS_SSL_VERIFY (#50)

### DIFF
--- a/birdy/cli/misc.py
+++ b/birdy/cli/misc.py
@@ -1,3 +1,4 @@
+import os
 import click
 
 
@@ -11,3 +12,18 @@ def monitor(execution):
         click.echo('Output:')
         for output in execution.processOutputs:
             click.echo('{}={}'.format(output.identifier, output.data or output.reference))
+
+
+def get_ssl_verify():
+    value = os.environ.get('WPS_SSL_VERIFY', 'True')
+    if value.lower() == 'true':
+        verify = True
+    elif value.lower() == 'false':
+        import urllib3
+        urllib3.disable_warnings()
+        click.echo('Warning: Unverified HTTPS request is being made.'
+                   ' Adding certificate verification is strongly advised.\n')
+        verify = False
+    else:
+        verify = value
+    return verify

--- a/birdy/cli/run.py
+++ b/birdy/cli/run.py
@@ -1,5 +1,6 @@
 import click
 from birdy.cli.base import BirdyCLI
+from birdy.cli.misc import get_ssl_verify
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -7,16 +8,15 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(cls=BirdyCLI, context_settings=CONTEXT_SETTINGS,
                url="http://localhost:5000/wps")
 @click.version_option()
-@click.option('--insecure', '-k', is_flag=True, help="Don't validate the server's certificate.")
 @click.option('--cert', help="Client side certificate containing both certificate and private key.")
 @click.option("--sync", '-s', is_flag=True, help="Execute process in sync mode. Default: async mode.")
 @click.option("--token", "-t", help="Token to access the WPS service.")
 @click.pass_context
-def cli(ctx, insecure, cert, sync, token):
+def cli(ctx, cert, sync, token):
     """
     Birdy is a command line client for Web Processing Services.
 
     Documentation is available on readthedocs:
     http://birdy.readthedocs.org/en/latest/
     """
-    ctx.obj = dict(insecure=insecure, cert=cert, sync=sync, token=token)
+    ctx.obj = dict(verify=get_ssl_verify(), cert=cert, sync=sync, token=token)

--- a/birdy/templates/cmd.py.j2
+++ b/birdy/templates/cmd.py.j2
@@ -1,10 +1,12 @@
 import click
 from click import STRING, INT, FLOAT, BOOL
+from requests.exceptions import SSLError
 from owslib.wps import WebProcessingService
 from owslib.wps import ComplexDataInput
 from owslib.wps import SYNC, ASYNC
 from birdy.cli.types import COMPLEX
 from birdy.cli.misc import monitor
+from birdy.exceptions import ConnectionError
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -21,7 +23,7 @@ def cli(ctx, **options):
     headers = {}
     if 'token' in ctx.obj:
         headers = {'Access-Token': ctx.obj['token']}
-    verify = not ctx.obj.get('insecure', False)
+    verify = ctx.obj.get('verify', True)
     cert = ctx.obj.get('cert')
     wps = WebProcessingService('{{ url }}', skip_caps=True, verify=verify, cert=cert, headers=headers)
     inputs = []
@@ -34,5 +36,8 @@ def cli(ctx, **options):
         mode = SYNC
     else:
         mode = ASYNC
-    execution = wps.execute('{{ name }}', inputs=inputs, output='output', mode=mode)
-    monitor(execution)
+    try:
+        execution = wps.execute('{{ name }}', inputs=inputs, output='output', mode=mode)
+        monitor(execution)
+    except SSLError:
+        raise ConnectionError('SSL verification of server certificate failed.')

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -18,7 +18,6 @@ Show the processes of a Web Processing Service:
 
     Options:
       --version         Show the version and exit.
-      -k, --insecure    Don't validate the server's certificate.
       --cert TEXT       Client side certificate containing both certificate and
                         private key.
       -s, --sync        Execute process in sync mode. Default: async mode.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -25,7 +25,6 @@ Get a list of available processes on WPS with URL http://localhost:5000/wps:
 
    Options:
      --version         Show the version and exit.
-     -k, --insecure    Don't validate the server's certificate.
      --cert TEXT       Client side certificate containing both certificate and
                        private key.
      -s, --sync        Execute process in sync mode. Default: async mode.
@@ -39,6 +38,19 @@ Get a list of available processes on WPS with URL http://localhost:5000/wps:
      bbox                      Bounding box in- and out: Give bounding box,...
      hello                     Say Hello: Just says a friendly Hello.Returns...
 
+Configure SSL verification for HTTPS
+------------------------------------
+
+In case you are a WPS serive using HTTPS with a self-signed certificate you need to configure
+the environment variable ``WPS_SSL_VERIFY``:
+
+.. code-block:: sh
+
+  $ export WPS_SSL_VERIFY=false  # deactivate SSL server validation for a self-signed certificate.
+
+You can also set the path of the service certificate.
+Read the `requests documentation <http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification>`_.
+
 
 Use client certificate to access WPS service
 --------------------------------------------
@@ -50,6 +62,7 @@ with the ``--cert`` option to a request.
 
    # set WPS service
    $ export WPS_SERVICE=https://localhost:5000/ows/proxy/emu
+   $ export WPS_SSL_VERIFY=false  # deactivate SSL server validation for a self-signed certificate.
    # available processes
    $ birdy -h
    # details of the "hello" process


### PR DESCRIPTION
## Overview

This PR fixes #50.

Changes:

* Using `WPS_SSL_VERIFY` environment variable to configure SSL verification.
* Removed the obsolete ``--insecure`` CLI option.
* Updated docs for HTTPS usage.

## Related Issue / Discussion

## Additional Information

