### PR TITLE
fix default value handling for complex input (#60)

### DIFF
--- a/birdy/native/client.py
+++ b/birdy/native/client.py
@@ -121,9 +121,14 @@ class BirdyClient(object):
 
         process = self._processes[pid]
 
+        # init defaults
         input_defaults = OrderedDict(
-            (i.identifier, getattr(i, "defaultValue", None)) for i in process.dataInputs
+            (i.identifier, None) for i in process.dataInputs
         )
+        # update with default values for literal data only
+        for i in process.dataInputs:
+            if i.dataType != 'ComplexData':
+                input_defaults[i.identifier] = getattr(i, "defaultValue", None)
 
         body = dedent("""
             inputs = locals()

--- a/birdy/native/utils.py
+++ b/birdy/native/utils.py
@@ -63,7 +63,7 @@ def format_type(obj):
             doc += obj.dataType
 
         if getattr(obj, "supportedValues", None):
-            doc += ", ".join([":mimetype:`{}`".format(f) for f in obj.supportedValues])
+            doc += ", ".join([":mimetype:`{}`".format(getattr(f, 'mimeType', f)) for f in obj.supportedValues])
 
         if getattr(obj, "crss", None):
             crss = ", ".join(obj.crss[:nmax])

--- a/birdy/templates/cmd.py.j2
+++ b/birdy/templates/cmd.py.j2
@@ -46,7 +46,7 @@ def cli(ctx, **options):
     else:
         mode = ASYNC
     try:
-        execution = wps.execute('{{ name }}', inputs=inputs, output='output', mode=mode)
+        execution = wps.execute('{{ name }}', inputs=inputs, mode=mode)
         monitor(execution)
     except SSLError:
         raise ConnectionError('SSL verification of server certificate failed.')

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # conda env create -f environment.yml
 name: birdy
 channels:
-  # - birdhouse
+  - birdhouse
   - conda-forge
   - defaults
 dependencies:


### PR DESCRIPTION
## Overview

This PR fixes #60.

Changes:

* Sets default value of `ComplexInput` to `None`.
* Fixes mimeType display in doc string for `ComplexInput`.
* Adds birdhouse channel to `environment.yml` to get patched `owslib`.

## Related Issue / Discussion

## Additional Information

