### PR TITLE
add WpsClient instance docstring describing available processes

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -116,6 +116,8 @@ class WPSClient(object):
         if interactive:
             self._setup_logging()
 
+        self.__doc__ = utils.build_wps_client_doc(self._wps, self._processes)
+
     def _setup_logging(self):
         self.logger.setLevel(logging.INFO)
         import sys
@@ -155,7 +157,7 @@ class WPSClient(object):
 
         func_builder = FunctionBuilder(
             name=sanitize(pid),
-            doc=utils.build_doc(process),
+            doc=utils.build_process_doc(process),
             args=["self"] + list(input_defaults),
             defaults=tuple(input_defaults.values()),
             body=body,

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -19,7 +19,42 @@ def filter_case_insensitive(names, complete_list):
     return contained, missing
 
 
-def build_doc(process):
+def build_wps_client_doc(wps, processes):
+    """Create WPSClient docstring.
+
+    Parameters
+    ----------
+    wps : owslib.wps.WebProcessingService
+    processes : Dict[str, owslib.wps.Process]
+
+    Returns
+    -------
+    str
+        The formatted docstring for this WPSClient
+    """
+    doc = [wps.identification.abstract,
+           "",
+           "Processes",
+           "---------",
+           ""]
+
+    for process_name, process in processes.items():
+        description = "{name}\n    {abstract}".format(
+            name=process_name,
+            abstract=process.abstract or "(No description)"
+        )
+        doc.append(description)
+        doc.append("")
+
+    if not processes:
+        doc.append("There aren't any available processes.")
+
+    doc.append("\n")
+
+    return "\n".join(doc)
+
+
+def build_process_doc(process):
     """Create docstring from process metadata."""
     doc = [process.abstract or "", ""]
 

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -39,8 +39,9 @@ def build_wps_client_doc(wps, processes):
            ""]
 
     for process_name, process in processes.items():
+        sanitized_name = sanitize(process_name)
         description = "{name}\n    {abstract}".format(
-            name=process_name,
+            name=sanitized_name,
             abstract=process.abstract or "(No description)"
         )
         doc.append(description)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,6 +37,11 @@ def test_wps_client_backward_compability():
 
 
 @pytest.mark.online
+def test_wps_docs(wps):
+    assert "Processes" in wps.__doc__
+
+
+@pytest.mark.online
 def test_wps_client_single_output(wps):
     msg, = wps.hello("david")
     assert msg == "Hello david"


### PR DESCRIPTION
## Overview

Add a docstring to WPSClient instances.

### example for `emu`
```
>>> emu = WPSClient(url='http://localhost:5000/wps')
>>> help(emu)  # or emu? in jupyter
WPS processes for testing and demos.

Processes
---------

ultimate_question
    This process gives the answer to the ultimate question of "What is the meaning of life?"

sleep
    Testing a long running process, in the sleep.This process will sleep for a given delay or 10 seconds if not a valid value.

nap
    This process will have a short nap for a given delay or 1 second if not a valid value. This process only supports synchronous WPS requests... so, make sure the nap does not take to long.

bbox
    Give bounding box, return the same

hello
    Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.

dummyprocess
    DummyProcess to check the WPS structure

wordcounter
    Counts words in a given text.

chomsky
    Generates a random chomsky text

inout
    Testing all WPS input and output parameters.

binaryoperatorfornumbers
    Performs operation on two numbers and returns the answer. This example process is taken from Climate4Impact.

show_error
    This process will fail intentionally with a WPS error message.

multiple_outputs
    Produces multiple files and returns a document with references to these files.

esgf_demo
    Shows how to use WPS metadata for processes using ESGF data.

output_formats
    Dummy process returning various output file formats.

poly_centroid
    Return the polygon's centroid coordinates. If the geometry contains multiple polygons, only the centroid of the first one will be computed. Do not use for serious computations, this is only a test process and uses a crude approximation.

ncmeta
    Dataset can be either a NetCDF file or an OpenDAP service.
```
