### PR TITLE
more readable display of `Output` namedtuple

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -216,6 +216,7 @@ class WPSClient(object):
 
         # Output type conversion
         Output = namedtuple('Output', [sanitize(o.identifier) for o in resp.processOutputs])
+        Output.__repr__ = utils.pretty_repr
         return Output(*[self._process_output(o, pid) for o in resp.processOutputs])
 
     def _console_monitor(self, execution, sleep=3):

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -54,7 +54,7 @@ def pretty_repr(obj, linebreaks=True):
             value=value
         ))
 
-    attribute_joiner = "\n" if linebreaks else ", "
+    attribute_joiner = ",\n" if linebreaks else ", "
     attributes = attribute_joiner.join(attributes)
 
     joiner = "\n" if linebreaks else ""

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -19,6 +19,48 @@ def filter_case_insensitive(names, complete_list):
     return contained, missing
 
 
+def pretty_repr(obj, linebreaks=True):
+    """Pretty repr for an Output
+
+    Parameters
+    ----------
+    obj : any type
+    linebreaks : bool
+        If True, split attributes with linebreaks
+    """
+    class_name = obj.__class__.__name__
+
+    try:
+        obj = obj._asdict()  # convert namedtuple to dict
+    except AttributeError:
+        pass
+
+    try:
+        items = obj.items()
+    except AttributeError:
+        try:
+            items = obj.__dict__.items()
+        except AttributeError:
+            return repr(obj)
+
+    attributes = []
+    indent = "    " if linebreaks else ""
+
+    for key, value in items:
+        value = pretty_repr(value, linebreaks=False)
+        attributes.append("{indent}{key}={value}".format(
+            indent=indent,
+            key=key,
+            value=value
+        ))
+
+    attribute_joiner = "\n" if linebreaks else ", "
+    attributes = attribute_joiner.join(attributes)
+
+    joiner = "\n" if linebreaks else ""
+    return joiner.join([class_name + "(", attributes, ")"])
+
+
 def build_wps_client_doc(wps, processes):
     """Create WPSClient docstring.
 


### PR DESCRIPTION
When displaying an Output element in a jupyter notebook, it is displayed in a long single line and it's hard to find a particular result.

## Before:

```
Output(string='test', int=1, float=5.6, boolean=True, angle=90.0, time=datetime.time(15, 45), date=datetime.date(2012, 5, 1), datetime=datetime.datetime(2018, 12, 12, 0, 0), string_choice='scissor', string_multiple_choice='gentle albatros', text=<owslib.wps.ComplexDataInput object at 0x7f427789fdd8>, dataset=<owslib.wps.ComplexDataInput object at 0x7f427789fda0>, bbox=<owslib.ows.BoundingBox object at 0x7f427789f8d0>)
```

## After:

```
Output(
    string='test',
    int=1,
    float=5.6,
    boolean=True,
    angle=90.0,
    time=datetime.time(15, 45),
    date=datetime.date(2012, 5, 1),
    datetime=datetime.datetime(2018, 12, 12, 0, 0),
    string_choice='scissor',
    string_multiple_choice='gentle albatros',
    text=ComplexDataInput(mimeType=None, encoding=None, schema=None, value='request didn&#39;t have a text file.'),
    dataset=ComplexDataInput(mimeType=None, encoding=None, schema=None, value='request didn&#39;t have a netcdf file.'),
    bbox=BoundingBox(minx=None, miny=None, maxx=None, maxy=None, crs=Crs(id='epsg:4326', naming_authority=None, category=None, type=None, authority='EPSG', version=None, code=4326, axisorder='yx', encoding='code'), dimensions=2)
)
```