### PR TITLE
updated notebooks

### DIFF
--- a/notebooks/c4cds.ipynb
+++ b/notebooks/c4cds.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10,18 +10,18 @@
     "from birdy.exceptions import ProcessIsNotComplete, ProcessFailed, ProcessCanceled\n",
     "from IPython.display import Image\n",
     "\n",
-    "cli = WPSClient('http://cp4cds-cn1.dkrz.de/wps', interactive=True)"
+    "cli = WPSClient('http://cp4cds-cn1.dkrz.de/wps', progress=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d0f1b8298e644155b61343143287f27f",
+       "model_id": "0f62b8dc25e54cd892359107f38656dc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -39,28 +39,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Output(\n",
-      "    output='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/98a02aac-f4b9-11e8-9e0a-f2e4655a10b7/tas_Amon_HadGEM2-ES_historical_r1i1p1_188412-190911.nc',\n",
-      "    ncdump='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/98a02aac-f4b9-11e8-9e0a-f2e4655a10b7/nc_dump.txt',\n",
-      "    preview='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/98a02aac-f4b9-11e8-9e0a-f2e4655a10b7/tas_Amon_HadGEM2-ES_historical_r1i1p1_188412-190911.png'\n",
+      "cmip5_regridderResponse(\n",
+      "    output='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/dc18e40c-f6e3-11e8-ba1c-f2e4655a10b7/tas_Amon_HadGEM2-ES_historical_r1i1p1_188412-190911.nc',\n",
+      "    ncdump='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/dc18e40c-f6e3-11e8-ba1c-f2e4655a10b7/nc_dump.txt',\n",
+      "    preview='http://cp4cds-cn1.dkrz.de:80/outputs/c4cds/dc18e40c-f6e3-11e8-ba1c-f2e4655a10b7/tas_Amon_HadGEM2-ES_historical_r1i1p1_188412-190911.png'\n",
       ")\n"
      ]
     }
    ],
    "source": [
     "try:\n",
-    "    output = result.get_output()\n",
+    "    output = result.get()\n",
     "except ProcessIsNotComplete:\n",
     "    print(\"Please wait ...\")\n",
     "except ProcessFailed:\n",
-    "    print(\"Sorry, ing went somethrong ...\")\n",
+    "    print(\"Sorry, somthing went somethrong ...\")\n",
     "except ProcessCanceled:\n",
     "    # TODO: canceled exception is not raised yet\n",
     "    print(\"Job was canceled.\")\n",
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -88,13 +88,6 @@
    "source": [
     "Image(output.preview)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/emu-example.ipynb
+++ b/notebooks/emu-example.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "emu = WPSClient(url='http://localhost:5000/wps')\n",
-    "emu_i = WPSClient(url='http://localhost:5000/wps', interactive=True)"
+    "emu_i = WPSClient(url='http://localhost:5000/wps', progress=True)"
    ]
   },
   {
@@ -42,9 +42,9 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0memu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhello\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0memu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhello\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
-       "Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.\n",
+       "Just says a friendly Hello. Returns a literal string output with Hello plus the inputed name.\n",
        "\n",
        "Parameters\n",
        "----------\n",
@@ -55,7 +55,7 @@
        "-------\n",
        "output : //www.w3.org/TR/xmlschema-2/#string\n",
        "    A friendly Hello from us.\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/src/birdy/notebooks/</home/david/src/birdy/birdy/native/client.py-4>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Documents/GitHub/birdhouse/birdy/notebooks/</Users/pingu/Documents/GitHub/birdhouse/birdy/birdy/client/base.py-4>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -91,7 +91,7 @@
     }
    ],
    "source": [
-    "emu.hello(name='Birdy')"
+    "emu.hello(name='Birdy').get()[0]"
    ]
   },
   {
@@ -108,17 +108,41 @@
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "66af4019377b4ecd89dba5ad143d1948",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, bar_style='info', description='Processing:'), Button(button_style='danger'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result = emu_i.sleep(delay='1.0')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
       "text/plain": [
        "'done sleeping'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "emu_i.sleep(delay='1.0')"
+    "result.get()[0]"
    ]
   },
   {
@@ -130,22 +154,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'http://localhost:5000/outputs/bcfe11b0-dee1-11e8-9762-b052162515fb/out.txt'"
+       "'http://localhost:5000/outputs/24731630-f6e6-11e8-a610-acde48001122/out.txt'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "emu.chomsky(times='5')"
+    "emu.chomsky(times='5').get()[0]"
    ]
   },
   {
@@ -159,13 +183,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0memu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minout\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstring\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'This is just a string'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'7'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'3.14'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mboolean\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'True'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'12:00:00'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdate\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'2012-05-01'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdatetime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'2016-09-02 12:00:00+00:00'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstring_choice\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'scissor'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstring_multiple_choice\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'gentle albatros'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m<\u001b[0m\u001b[0mowslib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mComplexData\u001b[0m \u001b[0mobject\u001b[0m \u001b[0mat\u001b[0m \u001b[0;36m0x7f40e38110b8\u001b[0m\u001b[0;34m>\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m<\u001b[0m\u001b[0mowslib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwps\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mComplexData\u001b[0m \u001b[0mobject\u001b[0m \u001b[0mat\u001b[0m \u001b[0;36m0x7f40e3811080\u001b[0m\u001b[0;34m>\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0memu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minout\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstring\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'This is just a string'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m7\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3.14\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mboolean\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mangle\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m90.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdate\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2012\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m5\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdatetime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdatetime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2016\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m9\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtzinfo\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtzutc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstring_choice\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'scissor'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstring_multiple_choice\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'gentle albatros'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Testing all WPS input and output parameters.\n",
        "\n",
@@ -179,6 +203,8 @@
        "    Enter a float number.\n",
        "boolean : //www.w3.org/TR/xmlschema-2/#boolean\n",
        "    Make your choice :)\n",
+       "angle : //www.w3.org/TR/xmlschema-2/#angle\n",
+       "    Enter an angle [0, 360] :)\n",
        "time : //www.w3.org/TR/xmlschema-2/#time\n",
        "    Enter a time like 12:00:00\n",
        "date : //www.w3.org/TR/xmlschema-2/#date\n",
@@ -189,9 +215,9 @@
        "    Choose one item form list.\n",
        "string_multiple_choice : {'sitting duck', 'flying goose', 'happy pinguin', 'gentle albatros'}//www.w3.org/TR/xmlschema-2/#string\n",
        "    Choose one or two items from list.\n",
-       "text : ComplexData:mimetype:`<owslib.wps.ComplexData object at 0x7f40e3811358>`\n",
-       "    Enter a URL pointing                            to a text document (optional)\n",
-       "dataset : ComplexData:mimetype:`<owslib.wps.ComplexData object at 0x7f40e3811240>`\n",
+       "text : ComplexData:mimetype:`text/plain`\n",
+       "    Enter a URL pointing to a text document (optional)\n",
+       "dataset : ComplexData:mimetype:`application/x-netcdf`\n",
        "    Enter a URL pointing to a NetCDF file (optional)\n",
        "\n",
        "Returns\n",
@@ -204,6 +230,8 @@
        "    Float\n",
        "boolean : //www.w3.org/TR/xmlschema-2/#boolean\n",
        "    Boolean\n",
+       "angle : //www.w3.org/TR/xmlschema-2/#angle\n",
+       "    Angle\n",
        "time : //www.w3.org/TR/xmlschema-2/#time\n",
        "    Time\n",
        "date : //www.w3.org/TR/xmlschema-2/#date\n",
@@ -214,13 +242,13 @@
        "    String Choice\n",
        "string_multiple_choice : //www.w3.org/TR/xmlschema-2/#string\n",
        "    String Multiple Choice\n",
-       "text : ComplexData:mimetype:`<owslib.wps.ComplexData object at 0x7f40e3811a58>`\n",
+       "text : ComplexData:mimetype:`text/plain`\n",
        "    Copy of input text file.\n",
-       "dataset : ComplexData:mimetype:`<owslib.wps.ComplexData object at 0x7f40e3811ba8>`, :mimetype:`<owslib.wps.ComplexData object at 0x7f40e3811be0>`\n",
+       "dataset : ComplexData:mimetype:`application/x-netcdf`, :mimetype:`text/plain`\n",
        "    Copy of input netcdf file.\n",
        "bbox : BoundingBoxData:mimetype:`epsg:4326`\n",
        "    Bounding Box\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/src/birdy/notebooks/</home/david/src/birdy/birdy/native/client.py-8>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Documents/GitHub/birdhouse/birdy/notebooks/</Users/pingu/Documents/GitHub/birdhouse/birdy/birdy/client/base.py-8>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -229,55 +257,7 @@
     }
    ],
    "source": [
-    "emu._convert_objects = True\n",
     "emu.inout?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/david/.conda/envs/birdy/lib/python3.6/site-packages/owslib/wps.py:1326: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.\n",
-      "  if not bboxDataElement:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['test',\n",
-       " 1,\n",
-       " 5.6,\n",
-       " True,\n",
-       " datetime.time(15, 45),\n",
-       " datetime.date(2012, 5, 1),\n",
-       " datetime.datetime(2018, 12, 12, 0, 0),\n",
-       " 'scissor',\n",
-       " 'gentle albatros',\n",
-       " \"request didn't have a text file.\",\n",
-       " \"request didn't have a netcdf file.\",\n",
-       " <owslib.ows.BoundingBox at 0x7f40e382b668>]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import datetime as dt\n",
-    "emu.inout(string='test', int=1, float=5.6, boolean=True, time='15:45', datetime=dt.datetime(2018, 12, 12), text=None, dataset=None)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similarly, the `multiple_outputs` function returns a `text/plain` file and `application/json` file. The converter will automatically convert the text file into a string, and the json file into a dictionary."
    ]
   },
   {
@@ -286,31 +266,76 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "my output file number 0\n"
+      "/Users/pingu/.conda/envs/birdy/lib/python3.6/site-packages/owslib/wps.py:1329: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.\n",
+      "  if not bboxDataElement:\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "import datetime as dt\n",
+    "result = emu.inout(string='test', int=1, float=5.6, boolean=True, time='15:45', datetime=dt.datetime(2018, 12, 12), text=None, dataset=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get result as object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'count': 2,\n",
-       " 'outputs': [{'name': 'output_0.txt',\n",
-       "   'url': 'http://localhost:5000/outputs/bd2ebe28-dee1-11e8-9762-b052162515fb/output_0.txt'},\n",
-       "  {'name': 'output_0.txt',\n",
-       "   'url': 'http://localhost:5000/outputs/bd2ebe28-dee1-11e8-9762-b052162515fb/output_0.txt'}]}"
+       "<owslib.wps.ComplexDataInput at 0x10709d8d0>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "out, ref = emu.multiple_outputs(2)\n",
-    "print(out)\n",
-    "ref"
+    "result.get(asobj=True).text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example with multiple_outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, the `multiple_outputs` function returns a `text/plain` file. The converter will automatically convert the text file into a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my output file number 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "out = emu.multiple_outputs(1).get(asobj=True)[0]\n",
+    "print(out)\n"
    ]
   }
  ],

--- a/notebooks/owslib.ipynb
+++ b/notebooks/owslib.ipynb
@@ -91,7 +91,7 @@
      "output_type": "stream",
      "text": [
       "Title:  Say Hello\n",
-      "Abstract:  Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.\n",
+      "Abstract:  Just says a friendly Hello. Returns a literal string output with Hello plus the inputed name.\n",
       " identifier=name, title=Your name, abstract=Please enter your name., data type=//www.w3.org/TR/xmlschema-2/#string\n",
       " Any value allowed\n",
       " Default Value: None \n",
@@ -121,7 +121,7 @@
       "Help on method hello in module birdy.client.base:\n",
       "\n",
       "hello(name=None) method of birdy.client.base.WPSClient instance\n",
-      "    Just says a friendly Hello.Returns a literal string output with Hello plus the inputed name.\n",
+      "    Just says a friendly Hello. Returns a literal string output with Hello plus the inputed name.\n",
       "    \n",
       "    Parameters\n",
       "    ----------\n",
@@ -193,7 +193,7 @@
     }
    ],
    "source": [
-    "z, = cli.binaryoperatorfornumbers(1, 2, operator='add')\n",
+    "z = cli.binaryoperatorfornumbers(1, 2, operator='add').get()[0]\n",
     "z"
    ]
   },
@@ -203,17 +203,10 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Output(string='This is just a string', int=7, float=3.14, boolean=True, angle=90.0, time=datetime.time(12, 0), date=datetime.date(2012, 5, 1), datetime=datetime.datetime(2016, 9, 2, 12, 0, tzinfo=tzutc()), string_choice='scissor', string_multiple_choice='gentle albatros', text='http://localhost:5000/outputs/c2df02c6-f357-11e8-8494-b052162515fb/input', dataset='http://localhost:5000/outputs/c2df02c6-f357-11e8-8494-b052162515fb/input.txt', bbox=<owslib.ows.BoundingBox object at 0x7ff7182411d0>)\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/david/.conda/envs/birdy/lib/python3.6/site-packages/owslib/wps.py:1326: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.\n",
+      "/Users/pingu/.conda/envs/birdy/lib/python3.6/site-packages/owslib/wps.py:1329: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.\n",
       "  if not bboxDataElement:\n"
      ]
     },
@@ -229,8 +222,7 @@
     }
    ],
    "source": [
-    "out = cli.inout()\n",
-    "print(out)\n",
+    "out = cli.inout().get()\n",
     "out.date"
    ]
   },
@@ -256,8 +248,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "http://localhost:5000/outputs/c2fc6208-f357-11e8-8494-b052162515fb/output_0.txt\n",
-      "http://localhost:5000/outputs/c2fc6208-f357-11e8-8494-b052162515fb/input.json\n"
+      "http://localhost:5000/outputs/c2b99f52-f6f1-11e8-b905-acde48001122/output_0.txt\n",
+      "http://localhost:5000/outputs/c2b99f52-f6f1-11e8-b905-acde48001122/input.json\n"
      ]
     }
    ],
@@ -278,21 +270,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "http://localhost:5000/outputs/c319eb84-f357-11e8-8494-b052162515fb/output_0.txt\n",
-      "http://localhost:5000/outputs/c319eb84-f357-11e8-8494-b052162515fb/input.json\n",
-      "my output file number 0\n",
-      "{'count': 1, 'outputs': [{'name': 'output_0.txt', 'url': 'http://localhost:5000/outputs/c4201e54-f357-11e8-8494-b052162515fb/output_0.txt'}]}\n"
+      "http://localhost:5000/outputs/c4f3bb5e-f6f1-11e8-8adb-acde48001122/output_0.txt\n",
+      "my output file number 0\n"
      ]
     }
    ],
    "source": [
-    "output, ref = cli.multiple_outputs(1)\n",
+    "output = cli.multiple_outputs(1).get()[0]\n",
     "print(output)\n",
-    "print(ref)\n",
-    "clic = WPSClient(url, convert_objects=True)\n",
-    "output, ref = clic.multiple_outputs(1)\n",
-    "print(output)\n",
-    "print(ref)"
+    "# as reference\n",
+    "output = cli.multiple_outputs(1).get(asobj=True)[0]\n",
+    "print(output)\n"
    ]
   }
  ],
@@ -312,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,7 @@ def wps():
 
 
 @pytest.mark.online
+# @pytest.mark.skip("52north wps is down.")
 def test_52north():
     """This WPS server has process and input ids with dots and dashes."""
     url = "http://geoprocessing.demo.52north.org:8080/wps/" \


### PR DESCRIPTION
## Overview

This PR updates the notebooks to the current birdy client interfaces. 

This is a follow-up of PR #85.

Changes:

* Notebook update to latest `WPSClient` with `WPSResult` output.
* Removed a `ComplexOutput` display in Emu example ... not working as expected.
* commented skip marker of 52 north test.

## Related Issue / Discussion

#85

## Additional Information


