### PR TITLE
When ssl verification is explicitly turned off, ignore warnings

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -64,6 +64,11 @@ class WPSClient(object):
         self._inputs = {}
         self._outputs = {}
 
+        if not verify:
+            import urllib3
+
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         self._wps = WebProcessingService(
             url,
             version=version,


### PR DESCRIPTION
## Overview

When we explicitly turn off ssl verification, the output of a jupyter notebook or the console progress is rapidly filled with warnings.

I think this should be turned off.