### PR TITLE
Object conversion is now nested and relies on extension

### DIFF
--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -65,21 +65,7 @@ class BaseConverter(object):
 
 class TextConverter(BaseConverter):
     mimetype = "text/plain"
-    extensions = ['txt', ]
-
-
-class CSVConverter(BaseConverter):
-    mimetype = "text/plain"
-    extensions = ['csv', ]
-
-    def convert(self):
-        """
-        Args:
-            data:
-        """
-        import csv
-        with open(self.file) as f:
-            return csv.reader(f)
+    extensions = ['txt', 'csv']
 
 
 class JSONConverter(BaseConverter):
@@ -276,5 +262,5 @@ def convert(output, path, converters=None):
         except ImportError:
             pass
 
-    warnings.warn(UserWarning("No converter was found for mime type: {}".format(output.mimeType)))
+    warnings.warn(UserWarning("No converter was found."))
     return output.reference

--- a/birdy/client/outputs.py
+++ b/birdy/client/outputs.py
@@ -3,11 +3,12 @@ from collections import namedtuple
 
 from birdy.utils import sanitize, delist
 from birdy.client import utils
-from birdy.client.converters import default_converters
+from birdy.client.converters import convert
 from birdy.exceptions import ProcessIsNotComplete, ProcessFailed
 from owslib.wps import WPSExecution
 import warnings
 import tempfile
+from pathlib import Path
 
 
 class WPSResult(WPSExecution):
@@ -15,11 +16,10 @@ class WPSResult(WPSExecution):
     def attach(self, wps_outputs, converters=None):
         """
         Args:
-            converters (dict): Correspondence of {mimetype: class} to convert
-                this mimetype to a python object.
+            converters (dict): Converter dictionary {name: object}
         """
         self._wps_outputs = wps_outputs
-        self._converters = converters or copy(default_converters)
+        self._converters = converters
         self._path = tempfile.mkdtemp()
 
     def get(self, asobj=False):
@@ -56,21 +56,7 @@ class WPSResult(WPSExecution):
             data = [utils.from_owslib(d, data_type) for d in output.data]
             return delist(data)
 
-        if convert_objects and output.mimeType:
-            # Try to convert the bytes to an object.
-            # The default converter can be modified by users modifying
-            # the `default` property of the converter class
-            # ex: ShpConverter().default = "fiona"
-            if output.mimeType in self._converters:
-                for cls in self._converters[output.mimeType]:
-                    try:
-                        converter = cls(output, path=self._path)
-                        return converter.convert()
-
-                    except ImportError:
-                        pass
-
-            warnings.warn(UserWarning("No converter was found for mime type: {}".format(output.mimeType)))
-            return output.reference
+        if convert_objects:
+            return convert(output, self._path, self._converters)
         else:
             return output.reference

--- a/birdy/client/outputs.py
+++ b/birdy/client/outputs.py
@@ -8,7 +8,6 @@ from birdy.exceptions import ProcessIsNotComplete, ProcessFailed
 from owslib.wps import WPSExecution
 import warnings
 import tempfile
-from pathlib import Path
 
 
 class WPSResult(WPSExecution):

--- a/notebooks/emu-example.ipynb
+++ b/notebooks/emu-example.ipynb
@@ -190,11 +190,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... or use the metalink library on the referenced metalink file:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "out = emu.multiple_outputs(1).get(asobj=False)[0]\n",
+    "print(out)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from metalink import download\n",
+    "download.get(out, '/tmp')"
+   ]
   }
  ],
  "metadata": {
@@ -213,7 +233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -8,5 +8,4 @@ dependencies:
   - ipywidgets
   - nodejs
   - pip:
-    - -e git+https://github.com/metalink-dev/pymetalink
-
+    - -e git+https://github.com/metalink-dev/pymetalink#egg=metalink

--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - ipywidgets
   - nodejs
   - pip:
-    - -e git+https://github.com/metalink-dev/pymetalink#egg=metalink
+    - -e git+https://github.com/bird-house/pymetalink@birdhouse#egg=metalink

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -270,6 +270,28 @@ def test_jsonconverter():
     fb.close()
 
 
+def test_zipconverter():
+    import zipfile
+    f = tempfile.mktemp(suffix='.zip')
+    zf = zipfile.ZipFile(f, mode='w')
+
+    a = tempfile.NamedTemporaryFile(mode='w', suffix='.json')
+    a.write(json.dumps({"a": 1}))
+    a.seek(0)
+
+    b = tempfile.NamedTemporaryFile(mode='w', suffix='.csv')
+    b.write('a, b, c\n1, 2, 3')
+    b.seek(0)
+
+    zf.write(a.name, arcname=os.path.split(a.name)[1])
+    zf.write(b.name, arcname=os.path.split(b.name)[1])
+    zf.close()
+
+    [oa, ob] = converters.convert(f, path='/tmp')
+    assert oa == {"a": 1}
+    assert len(ob.splitlines()) == 2
+
+
 class TestIsEmbedded():
     remote = 'http://remote.org'
     local = 'http://localhost:5000'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from birdy.client import converters
 from birdy.client.utils import is_embedded_in_request
 from birdy import WPSClient
+from io import StringIO, BytesIO
+import tempfile
+
 
 # These tests assume Emu is running on the localhost
 url = "http://localhost:5000/wps"
@@ -144,7 +147,7 @@ def test_asobj(wps):
 
     # If the converter is missing, we should still get the reference.
     with pytest.warns(UserWarning):
-        resp._converters.pop("text/plain")
+        resp._converters = []
         out = resp.get(asobj=True)
         assert out.output.startswith('http://')
 
@@ -221,14 +224,11 @@ def test_inputs(wps):
 @pytest.mark.online
 def test_netcdf(wps):
     import netCDF4 as nc
-    from birdy.client.converters import default_converters
+    from birdy.client.converters import Netcdf4Converter, JSONConverter
 
     # Xarray is the default converter. Use netCDF4 here.
-    converters = default_converters.copy()
-    converters['application/x-netcdf'] = converters['application/x-netcdf'][::-1]
-
     if nc.getlibversion() > "4.5":
-        m = WPSClient(url=url, processes=["output_formats"], converters=converters)
+        m = WPSClient(url=url, processes=["output_formats"], converters=[Netcdf4Converter, JSONConverter])
         ncdata, jsondata = m.output_formats().get(asobj=True)
         assert isinstance(ncdata, nc.Dataset)
         ncdata.close()
@@ -247,20 +247,27 @@ def count_class_methods(class_):
     )
 
 
-def test_converter():
-    j = converters.JSONConverter()
-    assert isinstance(j, converters.default_converters["application/json"][0])
-
-
 def test_jsonconverter():
-    j = converters.JSONConverter()
-
     d = {"a": 1}
     s = json.dumps(d)
-    assert j.convert_data(s) == d
+    b = bytes(s, 'utf8')
 
-    s = b'{"a": 1}'
-    assert j.convert_data(s) == d
+    fs = tempfile.NamedTemporaryFile(mode='w')
+    fs.write(s)
+    fs.file.seek(0)
+
+    fb = tempfile.NamedTemporaryFile(mode='w+b')
+    fb.write(b)
+    fb.file.seek(0)
+
+    j = converters.JSONConverter(fs.name)
+    assert j.convert() == d
+
+    j = converters.JSONConverter(fb.name)
+    assert j.convert() == d
+
+    fs.close()
+    fb.close()
 
 
 class TestIsEmbedded():


### PR DESCRIPTION
## Overview

Metalink and zip files previously only returned their internal files. This PR converts the files inside these objects as well, so the container is invisible if `asobj=True`.

Changes:

* The conversion logic is changed. Each converter has a priority attribute and it's ordered by the algorithm looking for appropriate converters. 

Based on `metalink` branch not yet merged, hence the conflicts with master. 
