### PR TITLE
Support passing multiple arguments

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -233,7 +233,7 @@ class WPSClient(object):
             if arg is None:
                 continue
 
-            values = [arg, ] if type(arg) not in [list, tuple] else arg
+            values = [arg, ] if not isinstance(arg, (list, tuple)) else arg
 
             for value in values:
                 if isinstance(input_param.defaultValue, ComplexData):

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -234,7 +234,7 @@ class WPSClient(object):
                 continue
 
             values = [arg, ] if type(arg) not in [list, tuple] else arg
-                
+
             for value in values:
                 if isinstance(input_param.defaultValue, ComplexData):
                     encoding = input_param.defaultValue.encoding

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -225,12 +225,17 @@ class WPSClient(object):
 
         return func
 
-    def _execute(self, pid, **kwargs):
-        """Execute the process."""
+    def _build_inputs(self, pid, **kwargs):
+        """Build the input sequence from the function arguments."""
         wps_inputs = []
         for name, input_param in self._inputs[pid].items():
-            value = kwargs.get(sanitize(name))
-            if value is not None:
+            arg = kwargs.get(sanitize(name))
+            if arg is None:
+                continue
+
+            values = [arg, ] if type(arg) not in [list, tuple] else arg
+                
+            for value in values:
                 if isinstance(input_param.defaultValue, ComplexData):
                     encoding = input_param.defaultValue.encoding
                     mimetype = input_param.defaultValue.mimeType
@@ -255,6 +260,11 @@ class WPSClient(object):
 
                 wps_inputs.append((name, inp))
 
+        return wps_inputs
+
+    def _execute(self, pid, **kwargs):
+        """Execute the process."""
+        wps_inputs = self._build_inputs(pid, **kwargs)
         wps_outputs = [
             (o.identifier, "ComplexData" in o.dataType)
             for o in self._outputs[pid].values()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,7 +189,7 @@ def test_inputs(wps):
     result = wps.inout(
         string="test string",
         int=3,
-        float=3.5,
+        float=(3.5, 1.),
         boolean=True,
         angle=67.,
         time=time_.isoformat(),
@@ -197,13 +197,16 @@ def test_inputs(wps):
         datetime=datetime_.isoformat(sep=" "),
         string_choice="rock",
         string_multiple_choice="sitting duck",
+        int_range=5,
+        any_value='7',
+        ref_value='Scots',
         text="some unsafe text &<",
         dataset="file://" + data_path("dummy.nc"),
     )
     expected = (
         "test string",
         3,
-        3.5,
+        4.5,
         True,
         67.,
         time_,
@@ -211,6 +214,9 @@ def test_inputs(wps):
         datetime_,
         "rock",
         "sitting duck",
+        5,
+        '7',
+        'Scots',
         "some unsafe text &<",
     )
     assert expected == result.get(asobj=True)[:-2]


### PR DESCRIPTION
## Overview

This PR fixes #127 

Changes:

* Added support to pass a tuple or list of arguments: `name=[arg1, arg2]`. birdy will convert it to a sequence of `(name, arg1), (name, arg2)`. 
* Fixed the inout test. 