### PR TITLE
Add converter creating link widget [WIP]

### DIFF
--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -199,6 +199,23 @@ class ImageConverter(BaseConverter):
         return IPython.display.Image(self.url)
 
 
+class LinkConverter(BaseConverter):
+    """Convert URL reference to active link."""
+    priority = -1
+
+    def check_dependencies(self):
+        return nb.is_notebook()
+
+    def convert(self):
+        from birdy.dependencies import ipywidgets as widgets
+        from birdy.dependencies import IPython
+        
+        if self.url:
+            w = widgets.HTML(value="<a href={0}>{0}</a>".format(self.url))
+            IPython.display.display(w)
+        return self.file
+
+
 class ZipConverter(BaseConverter):
     mimetype = 'application/zip'
     extensions = ['zip', ]
@@ -214,7 +231,7 @@ class ZipConverter(BaseConverter):
 def _find_converter(mimetype=None, extension=None, converters=()):
     """Return a list of compatible converters ordered by priority.
     """
-    select = []
+    select = [LinkConverter]
     for obj in converters:
         if (mimetype == obj.mimetype) or (extension in obj.extensions):
             select.append(obj)

--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -209,7 +209,7 @@ class LinkConverter(BaseConverter):
     def convert(self):
         from birdy.dependencies import ipywidgets as widgets
         from birdy.dependencies import IPython
-        
+
         if self.url:
             w = widgets.HTML(value="<a href={0}>{0}</a>".format(self.url))
             IPython.display.display(w)

--- a/birdy/client/outputs.py
+++ b/birdy/client/outputs.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 from birdy.utils import sanitize, delist
 from birdy.client import utils
-from birdy.client.converters import convert
+from birdy.client.converters import convert, LinkConverter
 from birdy.exceptions import ProcessIsNotComplete, ProcessFailed
 from owslib.wps import WPSExecution
 import warnings
@@ -47,6 +47,7 @@ class WPSResult(WPSExecution):
             output (owslib.wps.Output):
             convert_objects: If True, object_converters will be used.
         """
+
         # Get the data for recognized types.
         if output.data:
             data_type = output.dataType
@@ -58,4 +59,4 @@ class WPSResult(WPSExecution):
         if convert_objects:
             return convert(output, self._path, self._converters, self.verify)
         else:
-            return output.reference
+            return LinkConverter(output).convert()

--- a/notebooks/Interactive.ipynb
+++ b/notebooks/Interactive.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,9 +13,175 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Metalink content-type detected.\n",
+      "Downloading to /tmp/tmpv2ghx7wn/input.txt.\n",
+      "Downloading to /tmp/tmpv2ghx7wn/input_s7t44pe0.txt.\n",
+      "Metalink content-type detected.\n",
+      "Downloading to /tmp/tmpv2ghx7wn/input_7oijrx1f.txt.\n",
+      "Downloading to /tmp/tmpv2ghx7wn/input_0me8rwhy.txt.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "multiple_outputsResponse(\n",
+       "    output=['output: 0', 'output: 1'],\n",
+       "    output_meta4=['output: 0', 'output: 1']\n",
+       ")"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp = emu.multiple_outputs(2)\n",
+    "out, meta = resp.get(asobj=False)\n",
+    "resp.get(asobj=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from birdy.dependencies import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = widgets.HTML(value=\"<a href={0}>{0}</a>\".format(out))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"HTML(value='<a href=http://localhost:5000/outputs/917b0e68-8dd6-11e9-82a7-b052162515fb/input.metalink>http://localhost:5000/outputs/917b0e68-8dd6-11e9-82a7-b052162515fb/input.metalink</a>')\""
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import metalink"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function get in module metalink.download:\n",
+      "\n",
+      "get(src, path, checksums={}, force=False, handlers={}, segmented=True, headers={})\n",
+      "    Download a file, decodes metalinks.\n",
+      "    First parameter, file to download, URL or file path to download from\n",
+      "    Second parameter, file path to save to\n",
+      "    Third parameter, optional, expected dictionary of checksums\n",
+      "    Fourth parameter, optional, force a new download even if a valid copy already exists\n",
+      "    Fifth parameter, optional, progress handler callback\n",
+      "    Sixth parameter, optional, boolean to try using segmented downloads\n",
+      "    Returns list of file paths if download(s) is successful\n",
+      "    Returns False otherwise (checksum fails)\n",
+      "    raise socket.error e.g. \"Operation timed out\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(metalink.download.get)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Metalink content-type detected.\n",
+      "Resuming download of input.txt.\n",
+      "Downloading to /tmp/test.metalink/input.txt.\n",
+      "Downloading to /tmp/test.metalink/input_8jbw0vw6.txt.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['/tmp/test.metalink/input.txt', '/tmp/test.metalink/input_8jbw0vw6.txt']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metalink.download.get('http://localhost:5000/outputs/0b790c94-8dd5-11e9-82a7-b052162515fb/input.metalink', path='/tmp/test.metalink', segmented=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bb1b5ffdb58341c8a75dcd872a323000",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatText(value=2.0, description='Input 1'), FloatText(value=3.0, description='Input 2')…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "resp = nb_form(emu, 'binaryoperatorfornumbers')"
    ]
@@ -64,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Overview

This PR is an attempt to fix #130, but I don't think this is the solution. 

The issue is that we can't really "return" a link, because a link is an http string, not the url itself, which we need as an input argument for other processes. 

The solution in this branch is to create a widget that displays a clickable link, but it takes a lot of vertical space, and it's possibly confusing to users. I think it would be better to parse the outputs in javascript and convert URLs into links. The python interaction would not change, just the user interface. 
