### PR TITLE
ignore import warnings

### DIFF
--- a/birdy/dependencies.py
+++ b/birdy/dependencies.py
@@ -11,7 +11,7 @@ Example usage::
 import warnings
 from .exceptions import IPythonWarning
 
-warnings.filterwarnings('default', category=IPythonWarning)
+warnings.filterwarnings('ignore', category=IPythonWarning)
 
 try:
     import ipywidgets

--- a/birdy/dependencies.py
+++ b/birdy/dependencies.py
@@ -11,6 +11,8 @@ Example usage::
 import warnings
 from .exceptions import IPythonWarning
 
+# TODO: we ignore warnings for now. They are only needed when birdy is used in a notebook,
+# but we currently don't know how to handle this (see #89 and #138).
 warnings.filterwarnings('ignore', category=IPythonWarning)
 
 try:


### PR DESCRIPTION
## Overview

This PR fixes #89 

Changes:

* Ignores import warnings. 

Ideally, these warnings would be triggered when the dependencies are actually used, not at import time. 