### PR TITLE
Fix arguments ordering (fix #133)

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -165,20 +165,6 @@ class WPSClient(object):
 
         process = self._processes[pid]
 
-        def sort_inputs_key(i):
-            """Function used as key when sorting process inputs.
-
-            The order is:
-             - Inputs that have minOccurs >= 1 and no default value
-             - Inputs that have minOccurs >= 1 and a default value
-             - Every other input
-            """
-            return list(reversed([
-                i.minOccurs >= 1 and i.defaultValue is None,
-                i.minOccurs >= 1,
-                i.minOccurs == 0,
-            ]))
-
         required_inputs_first = sorted(process.dataInputs, key=sort_inputs_key)
 
         input_names = []
@@ -323,6 +309,27 @@ class WPSClient(object):
             self.logger.info("{} done.".format(execution.process.identifier))
         else:
             self.logger.info("{} failed.".format(execution.process.identifier))
+
+
+def sort_inputs_key(i):
+    """Function used as key when sorting process inputs.
+
+    The order is:
+     - Inputs that have minOccurs >= 1 and no default value
+     - Inputs that have minOccurs >= 1 and a default value
+     - Every other input
+
+    Parameters
+    ----------
+    i: owslib.wps.Input
+      An owslib Input
+    """
+    conditions = [
+        i.minOccurs >= 1 and i.defaultValue is None,
+        i.minOccurs >= 1,
+        i.minOccurs == 0,
+    ]
+    return [not c for c in conditions]  # False values are sorted first
 
 
 def nb_form(wps, pid):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,17 @@
 import datetime
 import os
-import pytest
 import json
-# from owslib import crs
-
+import tempfile
 from pathlib import Path
-
 from unittest import mock
+
+import pytest
+# from owslib import crs
 
 from birdy.client import converters, nb_form
 from birdy.client.base import sort_inputs_key
 from birdy.client.utils import is_embedded_in_request
 from birdy import WPSClient
-from io import StringIO, BytesIO
-import tempfile
 
 
 # These tests assume Emu is running on the localhost

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,11 @@ import json
 # from owslib import crs
 
 from pathlib import Path
+
+from unittest import mock
+
 from birdy.client import converters, nb_form
+from birdy.client.base import sort_inputs_key
 from birdy.client.utils import is_embedded_in_request
 from birdy import WPSClient
 from io import StringIO, BytesIO
@@ -251,6 +255,34 @@ def test_xarray_converter(wps):
     import xarray as xr
     ncdata, jsondata = wps.output_formats().get(asobj=True)
     assert isinstance(ncdata, xr.Dataset)
+
+
+def test_sort_inputs():
+    """
+    The order should be:
+     - Inputs that have minOccurs >= 1 and no default value
+     - Inputs that have minOccurs >= 1 and a default value
+     - Every other input
+    """
+
+    i = mock.Mock()
+    i.minOccurs = 1
+    i.defaultValue = None
+    assert sort_inputs_key(i) == [False, False, True]
+
+    i = mock.Mock()
+    i.minOccurs = 1
+    i.defaultValue = "default"
+    assert sort_inputs_key(i) == [True, False, True]
+
+    i = mock.Mock()
+    i.minOccurs = 0
+    assert sort_inputs_key(i) == [True, True, False]
+
+    i = mock.Mock()
+    i.minOccurs = 0
+    i.defaultValue = "default"
+    assert sort_inputs_key(i) == [True, True, False]
 
 
 def test_all_subclasses():


### PR DESCRIPTION
## Overview

This PR fixes #133

The order of the arguments is important when creating the method that wraps a wps process, because the default values have to be provided as a list of values. The matching with the arguments and the default values is done purely by the ordering of the arguments. 

Changes:

* There was a bug when ordering these arguments. Arguments that had `min_occurs >= 1` and a default value were ordered before arguments that had no default value.