### PR TITLE
Add custom authentication methods

### DIFF
--- a/birdy/client/__init__.py
+++ b/birdy/client/__init__.py
@@ -68,7 +68,7 @@ here is a simple example of how to use it::
     >>> auth = HTTPBasicAuth('user', 'pass')
     >>> wps = WPSClient('http://www.example.com/wps', auth=auth)
 
-The fact that any `requests`-compatible class is accepted, custom
+Because any `requests`-compatible class is accepted, custom
 authentication methods are implemented the same way as in `requests`.
 
 For example, to connect to a magpie_ protected wps, you can use the

--- a/birdy/client/__init__.py
+++ b/birdy/client/__init__.py
@@ -52,6 +52,37 @@ If a WPS server with a simple `hello` process is running on the local host on po
   >>> emu.hello('stranger')
   hello(output='Hello stranger')
 
+Authentication
+--------------
+If you want to connect to a server that requires authentication, the
+:class:`WPSClient` class accepts an `auth` argument that
+behaves exactly like in the popular `requests` module
+(see `requests Authentication`_)
+
+The simplest form of authentication is HTTP Basic Auth. Although
+wps processes are not commonly protected by this authentication method,
+here is a simple example of how to use it::
+
+    >>> from birdy import WPSClient
+    >>> from requests.auth import HTTPBasicAuth
+    >>> auth = HTTPBasicAuth('user', 'pass')
+    >>> wps = WPSClient('http://www.example.com/wps', auth=auth)
+
+The fact that any `requests`-compatible class is accepted, custom
+authentication methods are implemented the same way as in `requests`.
+
+For example, to connect to a magpie_ protected wps, you can use the
+requests-magpie_ module::
+
+    >>> from birdy import WPSClient
+    >>> from requests_magpie import MagpieAuth
+    >>> auth = MagpieAuth('https://www.example.com/magpie', 'user', 'pass')
+    >>> wps = WPSClient('http://www.example.com/wps', auth=auth)
+
+.. _requests Authentication: https://2.python-requests.org/en/master/user/authentication/
+.. _magpie: https://github.com/ouranosinc/magpie
+.. _requests-magpie: https://github.com/ouranosinc/requests-magpie
+
 """
 
 from .base import WPSClient, nb_form

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ wrapt
 funcsigs
 boltons
 pathlib
+requests

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,12 @@
 
 from setuptools import find_packages
 from setuptools import setup
+from pathlib import Path
+import re
 
-version = __import__('birdy').__version__
+with open(Path(__file__).parent / 'birdy' / '__init__.py', 'r') as f:
+    version = re.search(r'__version__ = [\'"](.+?)[\'"]', f.read()).group(1)
+
 description = 'Birdy provides a command-line tool to work with Web Processing Services.'
 long_description = (
     open('README.rst').read() + '\n' + open('AUTHORS.rst').read() + '\n' + open('CHANGES.rst').read()


### PR DESCRIPTION
## Overview

`owslib` doesn't use the same session for every request. Instead, it sends username, password and headers along with every request. I think the ideal solution would be for `owslib` to re-use the same session, but it requires much more work to implement... So we need to provide the headers that contain the authentication information when instantiating the `WebProcessingService` class.

My main use case is to be able to authenticate with a WPS service behind twitcher with a magpie adapter. I intend to use this small package: https://github.com/davidcaron/requests-magpie to provide the magpie authentication class.

It's working as-is, but I'm opened to suggestions for improvements.

Changes:

* Added an `auth` argument to the WPSClient. This argument is an instance of the base class `requests.auth.AuthBase`. I implemented it this way so that other `requests`-compatible authentication methods should be easy to use. 
