### PR TITLE
skip PY2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+dist: xenial   # required for Python >= 3.7
 language: python
 branches:
   only:
     - master
 python:
-  # - "2.7"
   - "3.6"
+  - "3.7"
 sudo: false
 install:
   # Python 3.x is default

--- a/birdy/cli/base.py
+++ b/birdy/cli/base.py
@@ -50,7 +50,7 @@ class BirdyCLI(click.MultiCommand):
     def list_commands(self, ctx):
         ctx.obj = True
         self._update_commands()
-        return self.commands.keys()
+        return list(self.commands.keys())
 
     def get_command(self, ctx, name):
         self._update_commands()

--- a/birdy/client/__init__.py
+++ b/birdy/client/__init__.py
@@ -85,4 +85,4 @@ requests-magpie_ module::
 
 """
 
-from .base import WPSClient, nb_form
+from .base import WPSClient, nb_form  # noqa: F401

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -235,7 +235,7 @@ class WPSClient(object):
     def _build_inputs(self, pid, **kwargs):
         """Build the input sequence from the function arguments."""
         wps_inputs = []
-        for name, input_param in self._inputs[pid].items():
+        for name, input_param in list(self._inputs[pid].items()):
             arg = kwargs.get(sanitize(name))
             if arg is None:
                 continue
@@ -274,7 +274,7 @@ class WPSClient(object):
         wps_inputs = self._build_inputs(pid, **kwargs)
         wps_outputs = [
             (o.identifier, "ComplexData" in o.dataType)
-            for o in self._outputs[pid].values()
+            for o in list(self._outputs[pid].values())
         ]
 
         mode = self._mode if self._processes[pid].storeSupported else SYNC
@@ -358,6 +358,6 @@ def nb_form(wps, pid):
     if wps._notebook:
         return notebook.interact(
             func=getattr(wps, sanitize(pid)),
-            inputs=wps._inputs[pid].items())
+            inputs=list(wps._inputs[pid].items()))
     else:
         return None

--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -1,17 +1,9 @@
 from distutils.version import StrictVersion
 from importlib import import_module
-import six
 from . import notebook as nb
 import tempfile
 from pathlib import Path
 from owslib.wps import Output
-import warnings
-
-
-if six.PY2:
-    from urllib import urlretrieve
-else:
-    from urllib.request import urlretrieve
 
 
 class BaseConverter(object):

--- a/birdy/client/outputs.py
+++ b/birdy/client/outputs.py
@@ -1,4 +1,3 @@
-from copy import copy
 from collections import namedtuple
 
 from birdy.utils import sanitize, delist
@@ -6,7 +5,6 @@ from birdy.client import utils
 from birdy.client.converters import convert
 from birdy.exceptions import ProcessIsNotComplete, ProcessFailed
 from owslib.wps import WPSExecution
-import warnings
 import tempfile
 
 
@@ -56,6 +54,6 @@ class WPSResult(WPSExecution):
             return delist(data)
 
         if convert_objects:
-            return convert(output, self._path, self._converters, self.verify)
+            return convert(output, self._path, self._converters, self.auth.verify)
         else:
             return output.reference

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -3,8 +3,7 @@ import datetime as dt
 import dateutil.parser
 from owslib.wps import ComplexDataInput
 from .. utils import sanitize, is_file
-import six
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 
 def filter_case_insensitive(names, complete_list):
@@ -13,7 +12,7 @@ def filter_case_insensitive(names, complete_list):
     missing = []
     complete_list_lower = set(map(str.lower, complete_list))
 
-    if isinstance(names, six.string_types):
+    if isinstance(names, str):
         names = [names, ]
 
     for name in names:
@@ -42,10 +41,10 @@ def pretty_repr(obj, linebreaks=True):
         pass
 
     try:
-        items = obj.items()
+        items = list(obj.items())
     except AttributeError:
         try:
-            items = obj.__dict__.items()
+            items = list(obj.__dict__.items())
         except AttributeError:
             return repr(obj)
 
@@ -86,7 +85,7 @@ def build_wps_client_doc(wps, processes):
            "---------",
            ""]
 
-    for process_name, process in processes.items():
+    for process_name, process in list(processes.items()):
         sanitized_name = sanitize(process_name)
         description = "{name}\n    {abstract}".format(
             name=sanitized_name,

--- a/birdy/utils.py
+++ b/birdy/utils.py
@@ -1,8 +1,7 @@
 import re
 import collections
 import base64
-import six
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from pathlib import Path
 
 
@@ -65,7 +64,7 @@ def sanitize(name):
 def delist(data):
     """If data is a sequence with a single element, returns this element, otherwise return the sequence."""
     if (
-        isinstance(data, collections.Iterable) and not isinstance(data, six.string_types) and len(data) == 1
+        isinstance(data, collections.abc.Iterable) and not isinstance(data, str) and len(data) == 1
     ):
         return data[0]
     return data

--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,9 @@ channels:
   - defaults
 dependencies:
   - pip
-  - six
   #- openssl
   - lxml
-  - owslib>=0.17
+  - owslib>=0.18
   - owslib-esgfwps=0.1.0
   - pathlib
   - click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 click
 jinja2
 lxml
-owslib>=0.17
-six
+owslib>=0.18
 wrapt
 funcsigs
 boltons

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ markers =
 	slow: mark test to be slow
 
 [flake8]
-ignore = F401,E402
+# ignore = F401,E402
 max-line-length = 120
 exclude =
 	.git,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,7 +66,7 @@ def test_wps_client_single_output(wps):
 
 @pytest.mark.online
 def test_wps_nb_form(wps):
-    for pid in wps._processes.keys():
+    for pid in list(wps._processes.keys()):
         if pid in ['bbox', ]:  # Unsupported
             continue
         nb_form(wps, pid)
@@ -294,7 +294,7 @@ def count_class_methods(class_):
     return len(
         [
             f
-            for f in class_.__dict__.values()
+            for f in list(class_.__dict__.values())
             if isinstance(f, types.MethodType) and not f.__name__.startswith("_")
         ]
     )
@@ -370,7 +370,7 @@ class TestIsEmbedded():
     def test_file_like(self):
         import io
         f = io.StringIO()
-        f.write(u"just a string")
+        f.write("just a string")
         f.seek(0)
 
         assert is_embedded_in_request(self.remote, f)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,3 +1,3 @@
 def test_dependencies():
-    from birdy.dependencies import ipywidgets as widgets
-    from birdy.dependencies import IPython
+    from birdy.dependencies import ipywidgets as widgets  # noqa: F401
+    from birdy.dependencies import IPython  # noqa: F401

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 from birdy import utils
 from .common import resource_file
-import six
 from pathlib import Path
 
 
@@ -41,24 +40,24 @@ class TestEncode:
 
     def test_local_fn(self):
         nc, enc = utils.embed(self.nc, 'application/x-netcdf')
-        assert isinstance(nc, six.binary_type)
+        assert isinstance(nc, bytes)
         assert enc == 'base64'
 
         xml, enc = utils.embed(self.xml, 'text/xml')
-        assert isinstance(xml, six.string_types)
+        assert isinstance(xml, str)
         assert enc == 'utf-8'
 
     def test_local_uri(self):
         xml, enc = utils.embed('file://' + self.xml, 'text/xml')
-        assert isinstance(xml, six.string_types)
+        assert isinstance(xml, str)
 
     def test_path(self):
         p = Path(self.nc)
 
         nc, enc = utils.embed(p, 'application/x-netcdf')
-        assert isinstance(nc, six.binary_type)
+        assert isinstance(nc, bytes)
 
     def test_file(self):
         with open(self.nc, 'rb') as fp:
             nc, enc = utils.embed(fp, 'application/x-netcdf')
-            assert isinstance(nc, six.binary_type)
+            assert isinstance(nc, bytes)


### PR DESCRIPTION
## Overview

This PR skips Python 2.x support.

Changes:

* Skip `six`.
* Run python `2to3`.
* Update OWSLib 0.18

## Related Issue / Discussion

## Additional Information

