### PR TITLE
handle python keywords

### DIFF
--- a/birdy/utils.py
+++ b/birdy/utils.py
@@ -3,6 +3,7 @@ import collections
 import base64
 from urllib.parse import urlparse
 from pathlib import Path
+import keyword
 
 
 # These mimetypes will be encoded in base64 when embedded in requests.
@@ -57,8 +58,13 @@ def is_file(path):
 
 
 def sanitize(name):
-    """Lower-case name and replace all non-ascii chars by `_`."""
-    return re.sub(r'\W|^(?=\d)', '_', name.lower())
+    """Lower-case name and replace all non-ascii chars by `_`.
+    If name is a Python keyword (like `return`) then add a trailing `_`.
+    """
+    new_name = re.sub(r'\W|^(?=\d)', '_', name.lower())
+    if keyword.iskeyword(new_name):
+        new_name = new_name + '_'
+    return new_name
 
 
 def delist(data):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,8 @@ def test_sanitize():
     assert utils.sanitize('My Output 1') == 'my_output_1'
     assert utils.sanitize('a.b') == 'a_b'
     assert utils.sanitize('a-b') == 'a_b'
+    assert utils.sanitize('return') == 'return_'
+    assert utils.sanitize('Finally') == 'finally_'
 
 
 def test_delist():


### PR DESCRIPTION
## Overview

This PR fixes #157. The `utils.sanitize` method adds a trailing `_` to Python keywords to avoid the error in issue #157.

Changes:

* Updated `utils.sanitize`.
* Updated tests.

## Related Issue / Discussion

#157

## Additional Information

Using `keyword` list:
https://www.programiz.com/python-programming/keyword-list
