### PR TITLE
Add ability to specify output for process execution

### DIFF
--- a/birdy/cli/__init__.py
+++ b/birdy/cli/__init__.py
@@ -45,5 +45,36 @@ with the ``--cert`` option to a request::
    # run hello with certificate
    $ birdy --cert cert.pem hello --name stranger
 
+Using the output_formats option for a process
+---------------------------------------------
+
+Each process also has a default option named `output_formats`. It can be used
+to override a process' output format's default values.
+
+This option takes three parameters; 
+
+The format identifier: the name given to it
+
+The ``as reference`` parameter: if the output is returned as a link of not. 
+Can be True, False, or None (which uses the process' default value)
+
+The MIME type: of which MIME type is the output. 
+Unless the process has multiple supported mime types, this can be left to None.
+
+Looking at the emu process `output_formats`, the JSON output's default's the ``as reference``
+parameter to False and returns the content directly::
+
+    $ birdy output_formats
+      Output:
+      netcdf=http://localhost:5000/outputs/d9abfdc4-08d6-11eb-9334-0800274cd70c/dummy.nc
+      json=['{"testing": [1, 2]}']
+
+We can then use the output_formats option to redefine it::
+
+    $ birdy output_formats --output_formats json True None
+      Output:
+      netcdf=http://localhost:5000/outputs/38e9aefe-08db-11eb-9334-0800274cd70c/dummy.nc
+      json=http://localhost:5000/outputs/38e9aefe-08db-11eb-9334-0800274cd70c/dummy.json
+
 .. _requests: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
 """

--- a/birdy/cli/run.py
+++ b/birdy/cli/run.py
@@ -26,11 +26,30 @@ def _set_language(ctx, param, value):
     CONTEXT_OBJ['language'] = value
 
 
+def _format_outputs(ctx, param, output_obj):
+    if output_obj:
+        output = output_obj[0]
+        ref = output_obj[1].lower()
+        mime = output_obj[2]
+        as_ref = None
+        if ref == "true":
+            as_ref = True
+        elif ref == "false":
+            as_ref = False
+        mimetype = mime if mime.lower() != "none" else None
+        formatted_output = [(output, as_ref, mimetype)]
+        print(formatted_output)
+        CONTEXT_OBJ['outputs'] = formatted_output
+
+
 @click.command(cls=BirdyCLI, context_settings=CONTEXT_SETTINGS,
                url="http://localhost:5000/wps")
 @click.version_option()
 @click.option('--cert', help="Client side certificate containing both certificate and private key.")
-@click.option('--output', help="Output format", nargs=2)
+@click.option('--outputs', expose_value=False, nargs=3, callback=_format_outputs,
+                           help="Modify output format (optional). Takes three arguments, output name, "
+                                "as_reference (True, False, or None for process default), and mimetype"
+                                "(None for process default).")
 @click.option('--send', '-S', is_flag=True, help="Send client side certificate to WPS. Default: false")
 @click.option("--sync", '-s', is_flag=True, help="Execute process in sync mode. Default: async mode.")
 @click.option("--token", "-t", help="Token to access the WPS service.")
@@ -41,7 +60,7 @@ def _set_language(ctx, param, value):
     "--show-languages", "-L", expose_value=False, is_flag=True, is_eager=True, callback=_show_languages,
     help="Show a list of accepted languages for the WPS service.")
 @click.pass_context
-def cli(ctx, cert, output, send, sync, token):
+def cli(ctx, cert, send, sync, token):
     """
     Birdy is a command line client for Web Processing Services.
 
@@ -54,4 +73,3 @@ def cli(ctx, cert, output, send, sync, token):
     ctx.obj['send'] = send
     ctx.obj['sync'] = sync
     ctx.obj['token'] = token
-    ctx.obj['output'] = output

--- a/birdy/cli/run.py
+++ b/birdy/cli/run.py
@@ -30,6 +30,7 @@ def _set_language(ctx, param, value):
                url="http://localhost:5000/wps")
 @click.version_option()
 @click.option('--cert', help="Client side certificate containing both certificate and private key.")
+@click.option('--output', help="Output format", nargs=2)
 @click.option('--send', '-S', is_flag=True, help="Send client side certificate to WPS. Default: false")
 @click.option("--sync", '-s', is_flag=True, help="Execute process in sync mode. Default: async mode.")
 @click.option("--token", "-t", help="Token to access the WPS service.")
@@ -40,7 +41,7 @@ def _set_language(ctx, param, value):
     "--show-languages", "-L", expose_value=False, is_flag=True, is_eager=True, callback=_show_languages,
     help="Show a list of accepted languages for the WPS service.")
 @click.pass_context
-def cli(ctx, cert, send, sync, token):
+def cli(ctx, cert, output, send, sync, token):
     """
     Birdy is a command line client for Web Processing Services.
 
@@ -53,3 +54,4 @@ def cli(ctx, cert, send, sync, token):
     ctx.obj['send'] = send
     ctx.obj['sync'] = sync
     ctx.obj['token'] = token
+    ctx.obj['output'] = output

--- a/birdy/cli/run.py
+++ b/birdy/cli/run.py
@@ -38,7 +38,6 @@ def _format_outputs(ctx, param, output_obj):
             as_ref = False
         mimetype = mime if mime.lower() != "none" else None
         formatted_output = [(output, as_ref, mimetype)]
-        print(formatted_output)
         CONTEXT_OBJ['outputs'] = formatted_output
 
 

--- a/birdy/cli/run.py
+++ b/birdy/cli/run.py
@@ -25,30 +25,10 @@ def _set_language(ctx, param, value):
         return
     CONTEXT_OBJ['language'] = value
 
-
-def _format_outputs(ctx, param, output_obj):
-    if output_obj:
-        output = output_obj[0]
-        ref = output_obj[1].lower()
-        mime = output_obj[2]
-        as_ref = None
-        if ref == "true":
-            as_ref = True
-        elif ref == "false":
-            as_ref = False
-        mimetype = mime if mime.lower() != "none" else None
-        formatted_output = [(output, as_ref, mimetype)]
-        CONTEXT_OBJ['outputs'] = formatted_output
-
-
 @click.command(cls=BirdyCLI, context_settings=CONTEXT_SETTINGS,
                url="http://localhost:5000/wps")
 @click.version_option()
 @click.option('--cert', help="Client side certificate containing both certificate and private key.")
-@click.option('--outputs', expose_value=False, nargs=3, callback=_format_outputs,
-                           help="Modify output format (optional). Takes three arguments, output name, "
-                                "as_reference (True, False, or None for process default), and mimetype"
-                                "(None for process default).")
 @click.option('--send', '-S', is_flag=True, help="Send client side certificate to WPS. Default: false")
 @click.option("--sync", '-s', is_flag=True, help="Execute process in sync mode. Default: async mode.")
 @click.option("--token", "-t", help="Token to access the WPS service.")

--- a/birdy/client/__init__.py
+++ b/birdy/client/__init__.py
@@ -79,6 +79,45 @@ requests-magpie_ module::
     >>> auth = MagpieAuth('https://www.example.com/magpie', 'user', 'pass')
     >>> wps = WPSClient('http://www.example.com/wps', auth=auth)
 
+Output format
+-------------
+
+Birdy automatically manages process output to reflect it's default values or 
+Birdy's own defaults.
+
+However, it's possible to customize the output of a process. Each process has an input
+named ``output_formats`, that takes a dictionary as a parameter::
+
+    # example format = {
+    #     'output_identifier': {
+    #         'as_ref': <True, False or None>
+    #         'mimetype': <MIME type as a string or None>,
+    #     },
+    # }
+
+    # A dictionary defining netcdf and json outputs
+    >>> custom_format = {
+    >>>     'netcdf': {
+    >>>         'as_ref': True,
+    >>>         'mimetype': 'application/json',
+    >>>     },
+    >>>     'json': {
+    >>>         'as_ref': False,
+    >>>         'mimetype': None
+    >>>     }
+    >>> }
+
+Utility functions can also be used to create this dictionary::
+
+    >>> custom_format = create_output_dictionary('netcdf', True, 'application/json')
+    >>> add_output_format(custom_format, 'json', False, None)
+
+The created dictionary can then be used with a process::
+
+    >>> cli = WPSClient("http://localhost:5000")
+    >>> z = cli.output_formats(output_formats=custom_format).get()
+    >>> z
+
 .. _requests Authentication: https://2.python-requests.org/en/master/user/authentication/
 .. _magpie: https://github.com/ouranosinc/magpie
 .. _requests-magpie: https://github.com/ouranosinc/requests-magpie

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -163,13 +163,13 @@ class WPSClient(object):
 
     @output_format.setter
     def output_format(self, outputs):
-        """Set ouput formats for processes. These will fed to the 'output' argument of the execute 
+        """Set ouput formats for processes. These will be fed to the 'output' argument of the execute 
         process call (see owslib.wps.WebProcessingService) and will be used for all processes 
         until reset with reset_outputs.
 
         ex: cli.output_format = [('netcdf', True), ('output', None, 'application/json')]
             Where only output_indentifier and as_ref are defined for netcdf, and
-            the 'output' identifier uses default process `as_ref` value and specifies
+            the 'output' identifier uses the default process `as_ref` value and specifies
             the mime type.
 
         Parameters
@@ -350,7 +350,7 @@ class WPSClient(object):
                 (o.identifier, "ComplexData" in o.dataType)
                 for o in list(self._outputs[pid].values())
             ]
-            
+
         mode = self._mode if self._processes[pid].storeSupported else SYNC
 
         try:

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -298,11 +298,21 @@ class WPSClient(object):
 
         return wps_inputs
 
+    def _parse_output_formats(self, outputs):
+        """Parse an output format dictionary into a list of tuples, as required by wps.execute()."""
+        if outputs:
+            output_dict = []
+            for key, values in outputs.items():
+                output_dict.append((key, values["as_ref"], values["mimetype"]))
+            return output_dict
+        else:
+            return None
+
     def _execute(self, pid, **kwargs):
         """Execute the process."""
         wps_inputs = self._build_inputs(pid, **kwargs)
 
-        wps_outputs = kwargs['output_formats']
+        wps_outputs = self._parse_output_formats(kwargs['output_formats'])
         if not wps_outputs:
             wps_outputs = [
                 (o.identifier, "ComplexData" in o.dataType)

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -46,6 +46,7 @@ class WPSClient(object):
         caps_xml=None,
         desc_xml=None,
         language=None,
+        output_format=None,
     ):
         """
         Args:
@@ -73,6 +74,7 @@ class WPSClient(object):
         self._notebook = notebook.is_notebook()
         self._inputs = {}
         self._outputs = {}
+        self._output_format = output_format
 
         if not verify:
             import urllib3
@@ -140,6 +142,15 @@ class WPSClient(object):
     @property
     def languages(self):
         return self._wps.languages
+
+    @property
+    def output_format(self):
+        return self._output_format
+
+    @output_format.setter
+    def output_format(self, formats=None):
+        self._output_format = formats
+
 
     def _get_process_description(self, processes=None, xml=None):
         """Return the description for each process.
@@ -297,10 +308,13 @@ class WPSClient(object):
     def _execute(self, pid, **kwargs):
         """Execute the process."""
         wps_inputs = self._build_inputs(pid, **kwargs)
-        wps_outputs = [
-            (o.identifier, "ComplexData" in o.dataType)
-            for o in list(self._outputs[pid].values())
-        ]
+
+        wps_outputs = self.output_format
+        if not wps_outputs:
+            wps_outputs = [
+                (o.identifier, "ComplexData" in o.dataType)
+                for o in list(self._outputs[pid].values())
+            ]
 
         mode = self._mode if self._processes[pid].storeSupported else SYNC
 

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -66,9 +66,6 @@ class WPSClient(object):
             version (str): WPS version to use.
             language (str): passed to :class:`owslib.wps.WebProcessingService`
                 ex: 'fr-CA', 'en_US'.
-            output_formats: List of tuples, ex -> [(output_identifier, as_ref, mime_type)], for wps.execute
-                Used to override the values that will be used by the processes.
-                see : https://github.com/geopython/OWSLib/blob/master/owslib/wps.py#L318
         """
         self._converters = converters
         self._interactive = progress

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -277,3 +277,53 @@ def extend_instance(obj, cls):
     base_cls = obj.__class__
     base_cls_name = obj.__class__.__name__
     obj.__class__ = type(base_cls_name, (cls, base_cls), {})
+
+
+def add_output_format(output_dictionary, output_identifier, as_ref=None, mimetype=None):
+    """Add an output format to an already existing dictionary.
+
+    Parameters
+    ----------
+    output_dictionary: dict
+        The dictionary (created with create_output_dictionary()) to which this
+        output format will be added.
+    output_identifier: str
+        Identifier of the output.
+    as_ref: True, False or None
+        Determines if this output will be returned as a reference or not.
+        None for process default.
+    mimetype: str or None
+        If the process supports multiple MIME types, it can be specified with this argument.
+        None for process default.
+    """
+    output_dictionary[output_identifier] = {
+        'as_ref': as_ref,
+        'mimetype': mimetype,
+    }
+
+
+def create_output_dictionary(output_identifier, as_ref=None, mimetype=None):
+    """Create an output format dictionary.
+
+    Parameters
+    ----------
+    output_identifier: str
+        Identifier of the output.
+    as_ref: True, False or None
+        Determines if this output will be returned as a reference or not.
+        None for process default.
+    mimetype: str or None
+        If the process supports multiple MIME types, it can be specified with this argument.
+        None for process default.
+
+    Returns
+    -------
+    output_dictionary: dict
+    """
+    output_dictionary = {
+        output_identifier: {
+            'as_ref': as_ref,
+            'mimetype': mimetype,
+        }
+    }
+    return output_dictionary

--- a/birdy/templates/cmd.py.j2
+++ b/birdy/templates/cmd.py.j2
@@ -47,7 +47,9 @@ def cli(ctx, **options):
     else:
         mode = ASYNC
     try:
-        execution = wps.execute('{{ name }}', inputs=inputs, output=ctx.obj.get('outputs'), mode=mode)
+        outputs = ctx.obj.get('outputs')
+        formats = [outputs] if outputs else None 
+        execution = wps.execute('{{ name }}', inputs=inputs, output=formats, mode=mode)
         monitor(execution)
     except SSLError:
         raise ConnectionError('SSL verification of server certificate failed.')

--- a/birdy/templates/cmd.py.j2
+++ b/birdy/templates/cmd.py.j2
@@ -12,15 +12,19 @@ from birdy.exceptions import ConnectionError
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.version_option(version="{{ version }}")
 {% for option in options %}
 @click.option('--{{ option.name }}', help='{{ option.help }}',
               type={{ option.type }}, multiple={{ option.multiple }})
 {% endfor %}
+@click.option('--output_formats', nargs=3,
+                           multiple=True,
+                           help="Modify output format (optional). Takes three arguments, output name, "
+                                "as_reference (True, False, or None for process default), and mimetype"
+                                "(None for process default).")
 @click.pass_context
-def cli(ctx, **options):
+def cli(ctx, output_formats, **options):
     """{{ help }}"""
     headers = {}
     if 'token' in ctx.obj:
@@ -42,12 +46,26 @@ def cli(ctx, **options):
             inputs.append(("{}".format(opt), options[opt]))
         else:
             inputs.append(("{}".format(opt), "{}".format(options[opt])))
+    formated_outputs = None
+    if output_formats:
+        formated_outputs = []
+        for format in output_formats:
+            output = format[0]
+            ref = format[1].lower()
+            mime = format[2]
+            as_ref = None
+            if ref == "true":
+                as_ref = True
+            elif ref == "false":
+                as_ref = False
+            mimetype = mime if mime.lower() != "none" else None
+            formated_outputs.append((output, as_ref, mimetype))
     if ctx.obj.get('sync', False):
         mode = SYNC
     else:
         mode = ASYNC
     try:
-        execution = wps.execute('{{ name }}', inputs=inputs, output=ctx.obj.get('outputs'), mode=mode)
+        execution = wps.execute('{{ name }}', inputs=inputs, output=formated_outputs, mode=mode)
         monitor(execution)
     except SSLError:
         raise ConnectionError('SSL verification of server certificate failed.')

--- a/birdy/templates/cmd.py.j2
+++ b/birdy/templates/cmd.py.j2
@@ -47,9 +47,7 @@ def cli(ctx, **options):
     else:
         mode = ASYNC
     try:
-        outputs = ctx.obj.get('outputs')
-        formats = [outputs] if outputs else None 
-        execution = wps.execute('{{ name }}', inputs=inputs, output=formats, mode=mode)
+        execution = wps.execute('{{ name }}', inputs=inputs, output=ctx.obj.get('outputs'), mode=mode)
         monitor(execution)
     except SSLError:
         raise ConnectionError('SSL verification of server certificate failed.')


### PR DESCRIPTION
## Overview

This PR addresses part of #163 

Changes:

* Property and function to modify the 'output' arguments used when executing a process for the client
* Added option to cli to specify output argument (list of a single tuple)

## Additional Information

For the client, it's possible to create a list of as many tuples (output_identifier, as_ref, mimetype) as one needs. For this PR I kept it simple and implemented it like the language property. The set outputs will override the automatically created outputs for each process until it's reset.

For the cli, since the number of arguments for options need to be fixed (at least from my comprehension of click.command), it's only possible to use a single output as an argument. Also, I ended up implementing an option with 3 arguments instead of a combination of flag (for `as_ref`) and single arg options because `as_ref` can be True, False or None, and using a flag removed the ability to use None (and therefore the default for a process).