### PR TITLE
Add a rioxarray converter for GeoTIFF files

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,8 @@ Authors
 
 * David Huard <huard.david@ouranos.ca>
 * Carsten Ehbrecht <ehbrecht@dkrz.de>
+
+Contributors
+************
+
+* Trevor James Smith <smith.trevorj@ouranos.ca> `@Zeitsperre <https://www.github.com/Zeitsperre>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Change History
 **************
 
+0.7.1 (unreleased)
+==================
+
+Changes:
+
+* Added a converter for loading GeoTIFF using xarray/rioxarray (#193).
+
 0.7.0 (2021-01-15)
 ==================
 

--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -2,6 +2,7 @@ import tempfile
 from distutils.version import StrictVersion
 from importlib import import_module
 from pathlib import Path
+from typing import Sequence, Union
 
 from owslib.wps import Output
 
@@ -166,7 +167,10 @@ class Meta4Converter(MetalinkConverter):
 
 class Netcdf4Converter(BaseConverter):
     mimetype = "application/x-netcdf"
-    extensions = ["nc", "nc4"]
+    extensions = [
+        "nc",
+        "nc4",
+    ]
     priority = 1
 
     def check_dependencies(self):
@@ -196,6 +200,7 @@ class XarrayConverter(BaseConverter):
     mimetype = "application/x-netcdf"
     extensions = [
         "nc",
+        "nc4",
     ]
     priority = 2
 
@@ -354,7 +359,12 @@ def find_converter(obj, converters):
     return _find_converter(mimetype, extension, converters=converters)
 
 
-def convert(output, path, converters=None, verify=True):
+def convert(
+    output: Union[Output, Path, str],
+    path: Union[str, Path],
+    converters: Sequence[BaseConverter] = None,
+    verify: bool = True,
+):
     """Convert a file to an object.
 
     Parameters

--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -265,6 +265,23 @@ class ImageConverter(BaseConverter):
 
 
 # TODO: Add test for this.
+class GeotiffRioxarrayConverter(BaseConverter):
+    mimetype = "image/tiff; subtype=geotiff"
+    extensions = ["tiff", "tif"]
+    priority = 3
+
+    def check_dependencies(self):
+        GeotiffRasterioConverter.check_dependencies(self)
+        self._check_import("rioxarray")
+
+    def convert(self):
+        import xarray  # isort: skip
+        import rioxarray  # noqa
+
+        return xarray.open_rasterio(self.file)
+
+
+# TODO: Add test for this.
 class GeotiffRasterioConverter(BaseConverter):
     mimetype = "image/tiff; subtype=geotiff"
     extensions = ["tiff", "tif"]

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -6,4 +6,4 @@ geojson
 pymetalink
 fiona
 rasterio
-gdal
+rioxarray


### PR DESCRIPTION
## Overview

Changes:

* Added a converter that opens GeoTIFF files with rioxarray (`xarray.open_rasterio()`) in the event that the environment shows it available.

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
