### PR TITLE
Remove 3.6 from test matrix. Add 3.10.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Install packages
       run: |
         sudo apt-get -y install pandoc
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.8
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -28,10 +28,10 @@ jobs:
       run: make test
     - name: Lint with flake8 ⚙️
       run: make lint
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.8
     - name: Check formatting with black ⚙️
       run: black --check --target-version py36 birdy tests
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.8
     - name: Build docs 🏗️
       run: make docs
-      if: matrix.python-version == 3.6
+      if: matrix.python-version == 3.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Install packages

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes:
 
 * Relax dependency check on GeoTiff rioxarray and rasterio converters due to some mysterious gdal error.
 * Remove tests with live 52North WPS server since it seems offline.
-
+* Remove Python 3.6 from test matrix and add 3.10.
 
 0.8.1 (2021-12-01)
 ==================


### PR DESCRIPTION
## Overview

This PR fixes #218 

Changes:

* Removed 3.6 from test matrix
* Added 3.10 to test matrix

## Related Issue / Discussion
3.6 is not supported anymore

