### PR TITLE
Use try except statement to fetch description of all processes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Change History
 Changes:
 
 * Fix docstring creation error occurring when the server identification abstract is None. See issue `228`.
-
+* Handle case where the server `describeProcess` does not understand "ALL" as the process identifier. See issue `229`.
 
 0.8.3 (2023-05-03)
 ==================

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -201,7 +201,7 @@ class WPSClient:
                 ps = self._wps.describeprocess("all", xml=xml)
                 return OrderedDict((p.identifier, p) for p in ps)
 
-            except (ServiceException, ValueError) as e:
+            except (ServiceException, ValueError):
                 processes = all_wps_processes
 
         # Check for invalid process names, i.e. not matching the getCapabilities response.

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -198,10 +198,10 @@ class WPSClient:
         if processes is None:
             try:
                 # Get the description for all processes in one request.
-                ps = self._wps.describeprocess("ALL", xml=xml)
+                ps = self._wps.describeprocess("all", xml=xml)
                 return OrderedDict((p.identifier, p) for p in ps)
 
-            except ServiceException as e:
+            except (ServiceException, ValueError) as e:
                 processes = all_wps_processes
 
         # Check for invalid process names, i.e. not matching the getCapabilities response.

--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -196,11 +196,12 @@ class WPSClient:
         all_wps_processes = [p.identifier for p in self._wps.processes]
 
         if processes is None:
-            if owslib.__version__ > "0.17.0":
+            try:
                 # Get the description for all processes in one request.
-                ps = self._wps.describeprocess("all", xml=xml)
+                ps = self._wps.describeprocess("ALL", xml=xml)
                 return OrderedDict((p.identifier, p) for p in ps)
-            else:
+
+            except ServiceException as e:
                 processes = all_wps_processes
 
         # Check for invalid process names, i.e. not matching the getCapabilities response.


### PR DESCRIPTION
## Overview

This PR fixes #229

Changes:

* Puts describeProcess call in try statement to have a fall over mechanism in case it's not supported by the server. 

## Related Issue / Discussion


## Additional Information
Geoserver does not seem to support that part of the specs. 


Links to other issues or sources.
