### PR TITLE
remove distutils for python>3.11 compatibility

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 ************
 
 * Trevor James Smith <smith.trevorj@ouranos.ca> `@Zeitsperre <https://www.github.com/Zeitsperre>`_
+* Nathan Collier <nathaniel.collier@gmail.com> `@nocollier <https://github.com/nocollier>`_

--- a/birdy/client/converters.py
+++ b/birdy/client/converters.py
@@ -2,12 +2,12 @@
 
 import tempfile
 from collections.abc import Sequence
-from distutils.version import StrictVersion
 from importlib import import_module
 from pathlib import Path
 from typing import Union
 
 from owslib.wps import Output
+from packaging.version import Version
 
 from birdy.utils import is_opendap_url
 
@@ -170,8 +170,8 @@ class Netcdf4Converter(BaseConverter):  # noqa: D101
         self._check_import("netCDF4")
         from netCDF4 import getlibversion
 
-        version = StrictVersion(getlibversion().split(" ")[0])
-        if version < StrictVersion("4.5"):
+        version = Version(getlibversion().split(" ")[0])
+        if version < Version("4.5"):
             raise ImportError("netCDF4 library must be at least version 4.5")
 
     def convert(self):  # noqa: D102


### PR DESCRIPTION
## Overview

This PR removes a dependency on the `distutils` package which was deprecated in python 3.10 and removed in 3.12. Instead we use the `packaging` package already in `requirements.txt` and being used in `base.py`. `packaging` was available back in 3.9 and so I believe this solution is backwards compatible. 

Tests passed for me for python 3.12.

Changes:

* `distutils.version.StrictVersion --> packaging.version.Version`
