### PR TITLE
Added a function for parsing AllowedValues

### DIFF
--- a/birdy/client/base.py
+++ b/birdy/client/base.py
@@ -284,7 +284,7 @@ class WPSClient:
 
         func_builder = FunctionBuilder(
             name=sanitize(pid),
-            doc=utils.build_process_doc(process),
+            doc=utils.build_process_doc(self._wps, process),
             args=["self"] + input_names,
             defaults=defaults,
             body=body,

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -180,8 +180,9 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     """
     nmax = 10
     doc = ""
-    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
-          "ows": "http://www.opengis.net/ows/1.1",
+    ns = {
+        "wps": "http://www.opengis.net/wps/1.0.0",
+        "ows": "http://www.opengis.net/ows/1.1",
     }
     for input_elem in process.xpath("DataInputs/Input"):
         if input_elem.find("ows:Identifier", namespaces=ns).text == input_id:

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -180,8 +180,9 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     """
     nmax = 10
     doc = ""
-    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
-          "ows": "http://www.opengis.net/ows/1.1",
+    ns = {
+        "wps": "http://www.opengis.net/wps/1.0.0",
+        "ows": "http://www.opengis.net/ows/1.1",
     }
     xml_tree = process._processDescription
     for input_elem in xml_tree.xpath("DataInputs/Input"):

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -180,11 +180,11 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     """
     nmax = 10
     doc = ""
-    ns = {
-        "wps": "http://www.opengis.net/wps/1.0.0",
-        "ows": "http://www.opengis.net/ows/1.1",
+    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
+          "ows": "http://www.opengis.net/ows/1.1",
     }
-    for input_elem in process.xpath("DataInputs/Input"):
+    xml_tree = process._processDescription
+    for input_elem in xml_tree.xpath("DataInputs/Input"):
         if input_elem.find("ows:Identifier", namespaces=ns).text == input_id:
             if input_elem.find(".//ows:AllowedValues", namespaces=ns) is not None:
                 if input_elem.find(".//ows:Range", namespaces=ns) is not None:

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -121,12 +121,14 @@ def build_wps_client_doc(
     return "\n".join(doc)
 
 
-def build_process_doc(process: Process) -> str:
+def build_process_doc(wps: WebProcessingService, process: Process) -> str:
     """
     Create docstring from process metadata.
 
     Parameters
     ----------
+    wps : owslib.wps.WebProcessingService
+        A WPS service.
     process : owslib.wps.Process
         A WPS process.
 
@@ -136,6 +138,7 @@ def build_process_doc(process: Process) -> str:
         The formatted docstring for this process.
     """
     doc = [process.abstract or "", ""]
+    _process = wps.describeprocess(process.identifier)
 
     # Inputs
     if process.dataInputs:
@@ -143,7 +146,7 @@ def build_process_doc(process: Process) -> str:
         doc.append("----------")
         for i in process.dataInputs:
             doc.append(
-                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier)}{format_type(i)}"
+                f"{sanitize(i.identifier)} : {format_allowed_values(_process, i.identifier)}{format_type(i)}"
             )
             doc.append(f"    {i.abstract or i.title}")
             # if i.metadata:
@@ -180,9 +183,8 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     """
     nmax = 10
     doc = ""
-    ns = {
-        "wps": "http://www.opengis.net/wps/1.0.0",
-        "ows": "http://www.opengis.net/ows/1.1",
+    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
+          "ows": "http://www.opengis.net/ows/1.1",
     }
     xml_tree = process._processDescription
     for input_elem in xml_tree.xpath("DataInputs/Input"):

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -192,9 +192,12 @@ def format_allowed_values(process: Process, input_id: str) -> str:
         if input_elem.find("ows:Identifier", namespaces=ns).text == input_id:
             if input_elem.find(".//ows:AllowedValues", namespaces=ns) is not None:
                 if input_elem.find(".//ows:Range", namespaces=ns) is not None:
-                    min_val = input_elem.find(".//ows:MinimumValue", namespaces=ns).text
-                    max_val = input_elem.find(".//ows:MaximumValue", namespaces=ns).text
-                    doc += "{" + f"'{min_val}'" + "->" + f"'{max_val}'" + "}"
+                    ranges = process.xpath(".//ows:Range", namespaces=ns)
+                    for r in ranges:
+                        min_val = r.find(".//ows:MinimumValue", namespaces=ns).text
+                        max_val = r.find(".//ows:MaximumValue", namespaces=ns).text
+                        spacing = r.find(".//ows:Spacing", namespaces=ns).text if r.find(".//ows:Spacing", namespaces=ns) is not None else 1
+                        doc += "{" + f"'{min_val}'" + "->" + f"'{max_val}'" + f" steps: '{spacing}'" + "}"
                 else:
                     values = input_elem.xpath(".//ows:Value", namespaces=ns)
                     allowed = [v.text for v in values]

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -143,7 +143,7 @@ def build_process_doc(process: Process) -> str:
         doc.append("----------")
         for i in process.dataInputs:
             doc.append(
-                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier) + format_type(i)}"
+                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier)}{format_type(i)}"
             )
             doc.append(f"    {i.abstract or i.title}")
             # if i.metadata:
@@ -170,7 +170,7 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     ----------
     process : owslib.wps.Process
         A WPS process.
-    input_id: str
+    input_id : str
         An Input identifier.
 
     Returns
@@ -178,9 +178,11 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     str
         The AllowedValues for the given Input.
     """
-    root = process._xml
     nmax = 10
     doc = ""
+    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
+          "ows": "http://www.opengis.net/ows/1.1",
+    }
     for input_elem in process.xpath("DataInputs/Input"):
         if input_elem.find("ows:Identifier", namespaces=ns).text == input_id:
             if input_elem.find(".//ows:AllowedValues", namespaces=ns) is not None:

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -142,7 +142,9 @@ def build_process_doc(process: Process) -> str:
         doc.append("Parameters")
         doc.append("----------")
         for i in process.dataInputs:
-            doc.append(f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier)}")
+            doc.append(
+                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier)}"
+            )
             doc.append(f"    {i.abstract or i.title}")
             # if i.metadata:
             #    doc[-1] += " ({})".format(', '.join(['`{} <{}>`_'.format(m.title, m.href) for m in i.metadata]))
@@ -168,19 +170,19 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     ----------
     process : owslib.wps.Process
         A WPS process.
-    input_id: str 
-        An Input identifier. 
+    input_id: str
+        An Input identifier.
 
     Returns
     -------
     str
         The AllowedValues for the given Input.
     """
-    root = process._xml 
+    root = process._xml
     nmax = 10
     doc = ""
     for input_elem in process.xpath("DataInputs/Input"):
-        if input_elem.find("ows:Identifier", namespaces=ns).text == input_id: 
+        if input_elem.find("ows:Identifier", namespaces=ns).text == input_id:
             if input_elem.find(".//ows:AllowedValues", namespaces=ns) is not None:
                 if input_elem.find(".//ows:Range", namespaces=ns) is not None:
                     min_val = input_elem.find(".//ows:MinimumValue", namespaces=ns).text

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -143,7 +143,7 @@ def build_process_doc(process: Process) -> str:
         doc.append("----------")
         for i in process.dataInputs:
             doc.append(
-                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier)}"
+                f"{sanitize(i.identifier)} : {format_allowed_values(process, i.identifier) + format_type(i)}"
             )
             doc.append(f"    {i.abstract or i.title}")
             # if i.metadata:

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -196,8 +196,19 @@ def format_allowed_values(process: Process, input_id: str) -> str:
                     for r in ranges:
                         min_val = r.find(".//ows:MinimumValue", namespaces=ns).text
                         max_val = r.find(".//ows:MaximumValue", namespaces=ns).text
-                        spacing = r.find(".//ows:Spacing", namespaces=ns).text if r.find(".//ows:Spacing", namespaces=ns) is not None else 1
-                        doc += "{" + f"'{min_val}'" + "->" + f"'{max_val}'" + f" steps: '{spacing}'" + "}"
+                        spacing = (
+                            r.find(".//ows:Spacing", namespaces=ns).text
+                            if r.find(".//ows:Spacing", namespaces=ns) is not None
+                            else 1
+                        )
+                        doc += (
+                            "{"
+                            + f"'{min_val}'"
+                            + "->"
+                            + f"'{max_val}'"
+                            + f" steps: '{spacing}'"
+                            + "}"
+                        )
                 else:
                     values = input_elem.xpath(".//ows:Value", namespaces=ns)
                     allowed = [v.text for v in values]

--- a/birdy/client/utils.py
+++ b/birdy/client/utils.py
@@ -183,8 +183,9 @@ def format_allowed_values(process: Process, input_id: str) -> str:
     """
     nmax = 10
     doc = ""
-    ns = {"wps": "http://www.opengis.net/wps/1.0.0",
-          "ows": "http://www.opengis.net/ows/1.1",
+    ns = {
+        "wps": "http://www.opengis.net/wps/1.0.0",
+        "ows": "http://www.opengis.net/ows/1.1",
     }
     xml_tree = process._processDescription
     for input_elem in xml_tree.xpath("DataInputs/Input"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from common import EMU_CAPS_XML, EMU_DESC_XML, URL_EMU, resource_file
 from birdy import WPSClient
 from birdy.client import nb_form
 from birdy.client.base import sort_inputs_key
-from birdy.client.utils import format_allowed_values, is_embedded_in_request
+from birdy.client.utils import is_embedded_in_request
 
 # 52 north WPS
 url_52n = "http://geoprocessing.demo.52north.org:8080/wps/WebProcessingService?service=WPS&version=1.0.0&request=GetCapabilities"  # noqa: E501

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from common import EMU_CAPS_XML, EMU_DESC_XML, URL_EMU, resource_file
 from birdy import WPSClient
 from birdy.client import nb_form
 from birdy.client.base import sort_inputs_key
-from birdy.client.utils import is_embedded_in_request
+from birdy.client.utils import is_embedded_in_request, format_allowed_values
 
 # 52 north WPS
 url_52n = "http://geoprocessing.demo.52north.org:8080/wps/WebProcessingService?service=WPS&version=1.0.0&request=GetCapabilities"  # noqa: E501
@@ -43,6 +43,13 @@ def test_emu_offline(wps_offline):  # noqa: D103
 
 def test_wps_supported_languages(wps_offline):  # noqa: D103
     assert wps_offline.languages.supported == ["en-US", "fr-CA"]
+
+
+def test_method_factory(wps_offline):
+    """Check the order of AllowedValues in the docstring of a WPSClient instance's method."""
+    func_doc = wps_offline._method_factory(pid="inout").__doc__
+    assert "{'rock', 'paper', 'scissor'}" in func_doc
+    assert "{'1'->'10' steps: '1'}{'100'->'200' steps: '10'}" in func_doc
 
 
 @pytest.mark.online

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,7 @@ def test_wps_supported_languages(wps_offline):  # noqa: D103
 def test_method_factory(wps_offline):
     """Check the order of AllowedValues in the docstring of a WPSClient instance's method."""
     func_doc = wps_offline._method_factory(pid="inout").__doc__
+    assert "{'1', '2', '3', '5', '7', '11'}" in func_doc
     assert "{'rock', 'paper', 'scissor'}" in func_doc
     assert "{'1'->'10' steps: '1'}{'100'->'200' steps: '10'}" in func_doc
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from common import EMU_CAPS_XML, EMU_DESC_XML, URL_EMU, resource_file
 from birdy import WPSClient
 from birdy.client import nb_form
 from birdy.client.base import sort_inputs_key
-from birdy.client.utils import is_embedded_in_request, format_allowed_values
+from birdy.client.utils import format_allowed_values, is_embedded_in_request
 
 # 52 north WPS
 url_52n = "http://geoprocessing.demo.52north.org:8080/wps/WebProcessingService?service=WPS&version=1.0.0&request=GetCapabilities"  # noqa: E501


### PR DESCRIPTION
## Overview

This PR fixes #277 

Changes:

* Added a helper function for parsing `AllowedValues`. The problem seemed to be that the attribute `allowedValues` of the `ProcessDescription` object was being parsed by `OWSLib` as a Python `set`, which is inherently unordered. Parsing the element `AllowedValues` directly from raw XML into a `list` ensures the original order of items in `AllowedValues` is preserved.

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
