### PR TITLE
Remove pytest-notebook

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - flake8 >=7.0.0
   - nbval >=0.9.5
   - pytest >=8.0.0
-  - pytest-notebook >=0.6.0
   # sphinx for rtd
   - ipykernel >=6.25.0
   - nbconvert >=7.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,6 @@ nbval >=0.9.6
 pip >=23.3
 pre-commit >=3.6.2
 pytest >=8.0.0
-pytest-notebook >=0.6.0
 sphinx-codeautolink
 sphinx-copybutton
 sphinx >=7.0.0,<8.2.0


### PR DESCRIPTION
## Overview

This PR removes a now-incompatible `pytest` plugin in order to ensure `pytest` continues working as expected.

Changes:

* Removed `pytest-notebook` (unused, unmaintained, incompatible with `pytest` v9.x, redundant with `nbval`)